### PR TITLE
Dungeon instances redux

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,7 +26,7 @@ import Player from "./player"
 import TileTemplatePreview from "./tile_template_preview"
 import DungeonEditor from "./dungeon_editor"
 
-Dungeon.init(socket, document.getElementById("dungeon"))
+Dungeon.init(socket, document.getElementById("dungeon_instance"))
 Player.init(socket, document.getElementById("player"))
 TileTemplatePreview.init(document.getElementById("character_preview"))
 TileTemplatePreview.init(document.getElementById("character_preview_small"))

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,10 +22,12 @@ import "phoenix_html"
 
 import socket from "./socket"
 import Dungeon from "./dungeon"
+import Player from "./player"
 import TileTemplatePreview from "./tile_template_preview"
 import DungeonEditor from "./dungeon_editor"
 
 Dungeon.init(socket, document.getElementById("dungeon"))
+Player.init(socket, document.getElementById("player"))
 TileTemplatePreview.init(document.getElementById("character_preview"))
 TileTemplatePreview.init(document.getElementById("character_preview_small"))
 DungeonEditor.init(document.getElementById("dungeon_editor"))

--- a/assets/js/dungeon.js
+++ b/assets/js/dungeon.js
@@ -31,6 +31,10 @@ let Dungeon = {
         console.log("joined the dungeons channel!")
       })
       .receive("error", resp => console.log("join failed", resp))
+
+    window.addEventListener('beforeunload', (event) => {
+      socket.disconnect()
+    })
   },
   setupWindowListeners(dungeonChannel){
     let suppressDefaultKeys = [37,38,39,40]

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -17,6 +17,10 @@ let Player = {
         console.log("joined the players channel!")
       })
       .receive("error", resp => console.log("join failed", resp))
+
+    window.addEventListener('beforeunload', (event) => {
+      socket.disconnect()
+    })
   }
 }
 

--- a/assets/js/player.js
+++ b/assets/js/player.js
@@ -1,0 +1,24 @@
+let Player = {
+  init(socket, element){ if(!element){ return }
+    let playerUserIdHash = element.getAttribute("data-location-id")
+    socket.connect()
+
+    let playerChannel   = socket.channel("players:" + playerUserIdHash)
+
+
+    playerChannel.on("message", (resp) => {
+      document.getElementById("short_comm").innerText = resp.message
+    })
+
+    playerChannel.on("ping", ({count}) => console.log("PING", count))
+
+    playerChannel.join()
+      .receive("ok", (resp) => {
+        console.log("joined the players channel!")
+      })
+      .receive("error", resp => console.log("join failed", resp))
+  }
+}
+
+export default Player
+

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,3 +22,6 @@ config :comeonin, :bcrypt_log_rounds, 4
 config :comeonin, :pbkdf2_rounds, 1
 
 config :dungeon_crawl, :generator, DungeonCrawl.MapGenerators.TestRooms
+
+# It might just be all the puts debugging console statements slowing things, try removing this when those are out
+config :ex_unit, :assert_receive_timeout, 300

--- a/instance_benchmark.exs
+++ b/instance_benchmark.exs
@@ -1,0 +1,86 @@
+defmodule InstanceBenchmark do
+  alias DungeonCrawl.Dungeon
+  alias DungeonCrawl.DungeonInstances
+  alias DungeonCrawl.DungeonInstances.{Map,MapTile}
+  alias DungeonCrawl.MapGenerators.TestRooms
+  alias DungeonCrawl.TileState.Parser
+
+  alias DungeonCrawl.DungeonProcesses.InstanceProcess
+
+  require Logger
+
+  def measure(function) do
+    function
+    |> :timer.tc
+    |> elem(0)
+    |> Kernel./(1_000_000)
+  end
+
+  def process_vs_db(iterations \\ 10_000) do
+    logger_level = Logger.level
+    Logger.configure level: :warn
+
+    IO.puts "Generating instance in DB:"
+    start_ms = :os.system_time(:millisecond)
+    {:ok, dungeon} = Dungeon.generate_map TestRooms, %{name: "TestBench"}
+    {:ok, %{dungeon: instance = %Map{}}} = DungeonInstances.create_map(dungeon.dungeon)
+    IO.puts "Took #{(:os.system_time(:millisecond) - start_ms) / 1000.0} seconds"
+
+    IO.puts "Generating and populating GenServer instance:"
+    start_ms = :os.system_time(:millisecond)
+    {:ok, process} = InstanceProcess.start_link([])
+    InstanceProcess.load_map(process, DungeonCrawl.Repo.preload(instance, :dungeon_map_tiles).dungeon_map_tiles)
+    IO.puts "Took #{(:os.system_time(:millisecond) - start_ms) / 1000.0} seconds"
+
+    IO.puts "Running experiements..."
+    db_timing_read_only = measure(fn() ->
+        for x <- 0..iterations, do: read_only_for_db(instance)
+      end)
+    IO.puts "DataBase  #{iterations} reads        took (seconds): #{db_timing_read_only}"
+
+    db_timing = measure(fn() ->
+        for x <- 0..iterations, do: check_state_and_move_tile_for_db(instance)
+      end)
+    IO.puts "DataBase  #{iterations} reads/writes took (seconds): #{db_timing}"
+
+    gen_server_timing = measure(fn() ->
+        for x <- 0..iterations, do: check_state_and_move_tile_for_process(process)
+      end)
+    IO.puts "GenServer #{iterations} reads        took (seconds): #{gen_server_timing_read_only}"
+
+    gen_server_timing_read_only = measure(fn() ->
+        for x <- 0..iterations, do: read_only_for_process(process)
+      end)
+    IO.puts "GenServer #{iterations} reads/writes took (seconds): #{gen_server_timing}"
+
+    Logger.configure level: logger_level
+  end
+
+  defp check_state_and_move_tile_for_db(instance) do
+    row = :rand.uniform(20)-1
+    col = :rand.uniform(20)-1
+    tile = DungeonInstances.get_map_tile(instance.id, row, col)
+    {:ok, _state} = Parser.parse(tile.state) # this'll be slowish
+    DungeonInstances.update_map_tile(tile, %{character: "X", z_index: :rand.uniform(5)})
+  end
+
+
+  defp read_only_for_db(instance) do
+    row = :rand.uniform(20)-1
+    col = :rand.uniform(20)-1
+    tile = DungeonInstances.get_map_tile(instance.id, row, col)
+  end
+
+  defp check_state_and_move_tile_for_process(process) do
+    row = :rand.uniform(20)-1
+    col = :rand.uniform(20)-1
+    tile = InstanceProcess.get_tile(process, row, col)
+    InstanceProcess.update_tile(process, tile.id, %{character: "X", z_index: :rand.uniform(5)})
+  end
+
+  defp read_only_for_process(process) do
+    row = :rand.uniform(20)-1
+    col = :rand.uniform(20)-1
+    tile = InstanceProcess.get_tile(process, row, col)
+  end
+end

--- a/lib/dungeon_crawl/action/move.ex
+++ b/lib/dungeon_crawl/action/move.ex
@@ -1,23 +1,22 @@
 defmodule DungeonCrawl.Action.Move do
-  alias DungeonCrawl.DungeonInstances, as: Dungeon
+  alias DungeonCrawl.DungeonProcesses.Instances
   alias DungeonCrawl.DungeonInstances.MapTile
   alias DungeonCrawl.TileState.Parser
 
   # todo: rename this
-  def go(%MapTile{} = entity_map_tile, %MapTile{} = destination) do
+  def go(%MapTile{} = entity_map_tile, %MapTile{} = destination, %Instances{} = state) do
     if _valid_move(destination) do
       top_tile = Map.take(destination, [:map_instance_id, :row, :col, :z_index])
-      {:ok, new_location} = Dungeon.update_map_tile(entity_map_tile, Map.put(top_tile, :z_index, top_tile.z_index+1))
-      old_location_top_tile = Dungeon.get_map_tile(Map.take(entity_map_tile, [:map_instance_id, :row, :col]))
+      {new_location, state} = Instances.update_map_tile(state, entity_map_tile, Map.put(top_tile, :z_index, top_tile.z_index+1))
+      old_location_top_tile = Instances.get_map_tile(state, Map.take(entity_map_tile, [:row, :col]))
       old_location = if old_location_top_tile, do: old_location_top_tile, else: Map.merge(%MapTile{}, Map.take(entity_map_tile, [:row, :col]))
-
-      {:ok, %{new_location: new_location, old_location: old_location}}
+      {:ok, %{new_location: new_location, old_location: old_location}, state}
     else
       # might change this later to have more info, ie, bumped wall, cant pass through solid rock, etc
       {:invalid}
     end
   end
-  def go(_, _), do: {:invalid}
+  def go(_, _, _), do: {:invalid}
 
   defp _valid_move(destination) do
     {:ok, state} = Parser.parse(destination.state)

--- a/lib/dungeon_crawl/action/move.ex
+++ b/lib/dungeon_crawl/action/move.ex
@@ -8,7 +8,8 @@ defmodule DungeonCrawl.Action.Move do
     if _valid_move(destination) do
       top_tile = Map.take(destination, [:map_instance_id, :row, :col, :z_index])
       {:ok, new_location} = Dungeon.update_map_tile(entity_map_tile, Map.put(top_tile, :z_index, top_tile.z_index+1))
-      old_location = Dungeon.get_map_tile(Map.take(entity_map_tile, [:map_instance_id, :row, :col]))
+      old_location_top_tile = Dungeon.get_map_tile(Map.take(entity_map_tile, [:map_instance_id, :row, :col]))
+      old_location = if old_location_top_tile, do: old_location_top_tile, else: Map.merge(%MapTile{}, Map.take(entity_map_tile, [:row, :col]))
 
       {:ok, %{new_location: new_location, old_location: old_location}}
     else

--- a/lib/dungeon_crawl/application.ex
+++ b/lib/dungeon_crawl/application.ex
@@ -14,6 +14,7 @@ defmodule DungeonCrawl.Application do
       supervisor(DungeonCrawlWeb.Endpoint, []),
       # Start your own worker by calling: DungeonCrawlWeb.Worker.start_link(arg1, arg2, arg3)
       # worker(DungeonCrawlWeb.Worker, [arg1, arg2, arg3]),
+      {DungeonCrawl.DungeonProcesses.InstanceRegistry, name: DungeonInstanceRegistry},
       {DynamicSupervisor, name: DungeonCrawl.DungeonProcesses.Supervisor, strategy: :one_for_one},
     ]
 

--- a/lib/dungeon_crawl/application.ex
+++ b/lib/dungeon_crawl/application.ex
@@ -14,6 +14,7 @@ defmodule DungeonCrawl.Application do
       supervisor(DungeonCrawlWeb.Endpoint, []),
       # Start your own worker by calling: DungeonCrawlWeb.Worker.start_link(arg1, arg2, arg3)
       # worker(DungeonCrawlWeb.Worker, [arg1, arg2, arg3]),
+      {DynamicSupervisor, name: DungeonCrawl.DungeonProcesses.Supervisor, strategy: :one_for_one},
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/dungeon_crawl/dungeon_instances/dungeon_instances.ex
+++ b/lib/dungeon_crawl/dungeon_instances/dungeon_instances.ex
@@ -146,6 +146,10 @@ defmodule DungeonCrawl.DungeonInstances do
       "down"  -> { 1,  0}
       "left"  -> { 0, -1}
       "right" -> { 0,  1}
+      "north" -> {-1,  0}
+      "south" -> { 1,  0}
+      "west"  -> { 0, -1}
+      "east"  -> { 0,  1}
       _       -> { 0,  0}
     end
   end

--- a/lib/dungeon_crawl/dungeon_processes/instance_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_process.ex
@@ -69,11 +69,23 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
 
   ## Defining GenServer Callbacks
 
+  # Possible future state
+  # The state of the GenServer is a tuple of three:
+  # 1st - Map of tile id (key) to %Program{} (value) for all living programs
+  # 2nd - Representation of the entire map. The first element of the tuple 
+  #       is a map with tile id (key) and the entire instance %MapTile{} (value).
+  #       The second element of the tuple is also a map, but indexes tile id (value)
+  #       by the row, col, and z_index (key)
+  # 3rd - boolean representing if the scheduler is running or not. If not, the
+  #       process is in an "idle" state. Otherwise, the process is "active" and
+  #       checks all the running programs for activity every XXX ms
+
   @impl true
   def init(:ok) do
-    # TODO: add these later when the whole instance is stored in the genserver instead of retrieved from Repo
-    #map_by_ids = %{}
-    #map_by_coords = %{} # along with row, col, zindex, just has a map id
+    #map = {
+    #        %{},
+    #        %{} # along with row, col, zindex, just has a map id
+    #      }
     active_programs = %{} # map_id associated with program
     {:ok, {active_programs}}
   end

--- a/lib/dungeon_crawl/dungeon_processes/instance_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_process.ex
@@ -4,7 +4,6 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
   require Logger
 
   alias DungeonCrawl.Scripting
-  alias DungeonCrawl.Scripting.Program
 
   ## Client API
 
@@ -126,8 +125,6 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
 
   @impl true
   def handle_info(:perform_actions, {program_contexts}) do
-#IO.puts "ticK"
-#IO.puts inspect program_contexts
     updated_program_contexts = _cycle_programs(program_contexts)
     _schedule()
 
@@ -160,12 +157,6 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
     else
       [ [line, updated_program_context] | _cycle_programs(program_contexts) ]
     end
-  end
-
-  defp _cycle_programs(args) do
-    IO.puts "not sure what these args are"
-    IO.puts inspect args
-    args
   end
 
   defp _handle_broadcasting(program_context) do

--- a/lib/dungeon_crawl/dungeon_processes/instance_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_process.ex
@@ -1,4 +1,4 @@
-defmodule DungeonCrawl.DungeonInstances.InstanceProcess do
+defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
   use GenServer, restart: :temporary
 
   require Logger

--- a/lib/dungeon_crawl/dungeon_processes/instance_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_process.ex
@@ -7,7 +7,7 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
 
   ## Client API
 
-  @timeout 1000
+  @timeout 100
 
   @doc """
   Starts the instance process.

--- a/lib/dungeon_crawl/dungeon_processes/instance_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_process.ex
@@ -98,10 +98,10 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
 
   @impl true
   def handle_cast({:start_program, {map_tile_id, program_context}}, {program_contexts}) do
-IO.puts "start prog"
-IO.puts inspect map_tile_id
-IO.puts inspect program_context
-IO.puts inspect program_contexts
+#IO.puts "start prog"
+#IO.puts inspect map_tile_id
+#IO.puts inspect program_context
+#IO.puts inspect program_contexts
     if Map.has_key?(program_contexts, map_tile_id) do
       # already a running program for that tile id, or there is no map tile for that id
       {:noreply, {program_contexts}}

--- a/lib/dungeon_crawl/dungeon_processes/instance_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_process.ex
@@ -55,17 +55,17 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
   end
 
   @doc """
-  Send an event to a tile/program.
-  """
-  def send_event(instance, tile_id, event, sender) do
-    GenServer.cast(instance, {:send_event, {tile_id, event, sender}})
-  end
-
-  @doc """
   Check is a tile/program responds to an event
   """
   def responds_to_event?(instance, tile_id, event) do
     GenServer.call(instance, {:responds_to_event?, {tile_id, event}})
+  end
+
+  @doc """
+  Send an event to a tile/program.
+  """
+  def send_event(instance, tile_id, event, sender) do
+    GenServer.cast(instance, {:send_event, {tile_id, event, sender}})
   end
 
   ## Defining GenServer Callbacks
@@ -98,10 +98,6 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
 
   @impl true
   def handle_cast({:start_program, {map_tile_id, program_context}}, {program_contexts}) do
-#IO.puts "start prog"
-#IO.puts inspect map_tile_id
-#IO.puts inspect program_context
-#IO.puts inspect program_contexts
     if Map.has_key?(program_contexts, map_tile_id) do
       # already a running program for that tile id, or there is no map tile for that id
       {:noreply, {program_contexts}}
@@ -133,7 +129,7 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
 #IO.puts "ticK"
 #IO.puts inspect program_contexts
     updated_program_contexts = _cycle_programs(program_contexts)
-    #_schedule()
+    _schedule()
 
     {:noreply, {updated_program_contexts}}
   end
@@ -142,6 +138,10 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
     Process.send_after(self(), :perform_actions, @timeout)
   end
 
+  @doc """
+  Cycles through all the programs, running each until a wait point. Any messages for broadcast or a single player
+  will be broadcast. Typically this will only be called by the scheduler.
+  """
   defp _cycle_programs(program_contexts) when is_map(program_contexts) do
     program_contexts
     |> Enum.flat_map(fn({k,v}) -> [[k,v]] end)

--- a/lib/dungeon_crawl/dungeon_processes/instance_registry.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_registry.ex
@@ -1,6 +1,8 @@
 defmodule DungeonCrawl.DungeonProcesses.InstanceRegistry do
   use GenServer
 
+  require Logger
+
   alias DungeonCrawl.DungeonProcesses.{InstanceProcess,Supervisor}
   alias DungeonCrawl.DungeonInstances
   alias DungeonCrawl.Repo
@@ -46,6 +48,10 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceRegistry do
     GenServer.cast(server, {:create, instance_id})
   end
 
+  def remove(server, instance_id) do
+    GenServer.cast(server, {:remove, instance_id})
+  end
+
   ## Defining GenServer Callbacks
 
   @impl true
@@ -60,7 +66,7 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceRegistry do
     {instance_ids, _} = state
     {:reply, Map.fetch(instance_ids, instance_id), state}
   end
-require Logger
+
   @impl true
   def handle_cast({:create, instance_id}, {instance_ids, refs}) do
     if Map.has_key?(instance_ids, instance_id) do
@@ -80,6 +86,12 @@ require Logger
         {:noreply, {instance_ids, refs}}
       end
     end
+  end
+
+  @impl true
+  def handle_cast({:remove, instance_id}, {instance_ids, refs}) do
+    if Map.has_key?(instance_ids, instance_id), do: GenServer.stop(Map.fetch!(instance_ids, instance_id), :shutdown)
+    {:noreply, {instance_ids, refs}}
   end
 
   @impl true

--- a/lib/dungeon_crawl/dungeon_processes/instance_registry.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_registry.ex
@@ -23,7 +23,6 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceRegistry do
     GenServer.call(server, {:lookup, instance_id})
   end
 
-
   @doc """
   Looks up or creates the instance pid for `instance_id` stored in `server`.
 

--- a/lib/dungeon_crawl/dungeon_processes/instance_registry.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_registry.ex
@@ -1,0 +1,70 @@
+defmodule DungeonCrawl.DungeonProcesses.InstanceRegistry do
+  use GenServer
+
+  alias DungeonCrawl.DungeonProcesses.{InstanceProcess,Supervisor}
+
+  ## Client API
+
+  @doc """
+  Starts the registry.
+  """
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, :ok, opts)
+  end
+
+  @doc """
+  Looks up the instance pid for `instance_id` stored in `server`.
+
+  Returns `{:ok, pid}` if the instance exists, `:error` otherwise.
+  """
+  def lookup(server, instance_id) do
+    GenServer.call(server, {:lookup, instance_id})
+  end
+
+  @doc """
+  Ensures there is a instance associated with the given `instance_id` in `server`.
+  """
+  def create(server, instance_id) do
+    GenServer.cast(server, {:create, instance_id})
+  end
+
+  ## Defining GenServer Callbacks
+
+  @impl true
+  def init(:ok) do
+    instance_ids = %{}
+    refs = %{}
+    {:ok, {instance_ids, refs}}
+  end
+
+  @impl true
+  def handle_call({:lookup, instance_id}, _from, state) do
+    {instance_ids, _} = state
+    {:reply, Map.fetch(instance_ids, instance_id), state}
+  end
+
+  @impl true
+  def handle_cast({:create, instance_id}, {instance_ids, refs}) do
+    if Map.has_key?(instance_ids, instance_id) do
+      {:noreply, {instance_ids, refs}}
+    else
+      {:ok, pid} = DynamicSupervisor.start_child(Supervisor, InstanceProcess)
+      ref = Process.monitor(pid)
+      refs = Map.put(refs, ref, instance_id)
+      instance_ids = Map.put(instance_ids, instance_id, pid)
+      {:noreply, {instance_ids, refs}}
+    end
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, {instance_ids, refs}) do
+    {instance_id, refs} = Map.pop(refs, ref)
+    instance_ids = Map.delete(instance_ids, instance_id)
+    {:noreply, {instance_ids, refs}}
+  end
+
+  @impl true
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+end

--- a/lib/dungeon_crawl/dungeon_processes/instances.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instances.ex
@@ -1,34 +1,254 @@
 defmodule DungeonCrawl.DungeonProcesses.Instances do
   @moduledoc """
-  The instances context. This wraps InstanceRegistry lookups and InstanceProcess methods
-  for convenience.
+  The instances context.
+  It wraps the retrival and changes of %Instances{}
   """
 
-  alias DungeonCrawl.DungeonProcesses.{InstanceRegistry,InstanceProcess}
+  defstruct program_contexts: %{}, map_by_ids: %{}, map_by_coords: %{}, dirty_ids: %{}
+
+  alias DungeonCrawl.DungeonInstances.MapTile
+  alias DungeonCrawl.DungeonProcesses.Instances
+  alias DungeonCrawl.TileState
+  alias DungeonCrawl.Scripting
+  alias DungeonCrawl.Scripting.Runner
+
+  require Logger
 
   @doc """
-  Gets the top map tile in the given directon from the provided coordinates.
+  Returns the top map tile in the given directon from the provided coordinates.
   """
-  def get_map_tile(%{row: row, col: col} = map_tile, direction \\ nil) do
-    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, map_tile.map_instance_id)
-    InstanceProcess.get_tile(instance, row, col, direction)
+  def get_map_tile(state, %{row: row, col: col} = _map_tile, direction) do
+    {d_row, d_col} = _direction_delta(direction)
+    get_map_tile(state, %{row: row + d_row, col: col + d_col})
+  end
+  def get_map_tile(%Instances{map_by_ids: by_id, map_by_coords: by_coords} = _state, %{row: row, col: col} = _map_tile) do
+    with tiles when is_map(tiles) <- by_coords[{row, col}],
+         [{_z_index, top_tile}] <- Map.to_list(tiles)
+                                   |> Enum.sort(fn({a,_},{b,_}) -> a > b end)
+                                   |> Enum.take(1) do
+      by_id[top_tile]
+    else
+      _ ->
+        nil
+    end
+  end
+
+  @doc """
+  Returns the map tiles in the given directon from the provided coordinates.
+  """
+  def get_map_tiles(%Instances{} = state, %{row: row, col: col} = _map_tile, direction) do
+    {d_row, d_col} = _direction_delta(direction)
+    Instances.get_map_tiles(state, %{row: row + d_row, col: col + d_col})
+  end
+  def get_map_tiles(%Instances{map_by_ids: by_id, map_by_coords: by_coords} = _state, %{row: row, col: col} = _map_tile) do
+    with tiles when is_map(tiles) <- by_coords[{row, col}],
+         tiles <- Map.to_list(tiles)
+                  |> Enum.sort(fn({a,_},{b,_}) -> a > b end)
+                  |> Enum.map(fn({_, tile_id}) -> by_id[tile_id] end) do
+      tiles
+    else
+      _ ->
+        []
+    end
   end
 
   @doc """
   Gets the map tile given by the id.
   """
-  def get_map_tile_by_id(%{id: map_tile_id} = map_tile) do
-    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, map_tile.map_instance_id)
-    InstanceProcess.get_tile(instance, map_tile_id)
+  def get_map_tile_by_id(%Instances{map_by_ids: by_id} = _state, %{id: map_tile_id} = _map_tile) do
+    by_id[map_tile_id]
   end
 
   @doc """
-  Updates the given map tile in the parent instance process, and returns the updated tile.
+  Returns true or false, depending on if the given tile_id responds to the event.
   """
-  def update_map_tile(map_tile, new_attrs) do
-    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, map_tile.map_instance_id)
-    InstanceProcess.update_tile(instance, map_tile.id, new_attrs)
-    InstanceProcess.get_tile(instance, map_tile.id)
+  def responds_to_event?(%Instances{program_contexts: program_contexts} = _state, %{id: map_tile_id}, event) do
+    with %{^map_tile_id => %{program: program}} <- program_contexts,
+         labels <- program.labels[event],
+         true <- is_list(labels) do
+      Enum.any?(labels, fn([_, active]) -> active end)
+    else
+      _ ->
+        false
+    end
+  end
+
+  @doc """
+  Send an event to a tile/program.
+  Returns the updated state.
+  """
+  def send_event(%Instances{program_contexts: program_contexts} = state, %{id: map_tile_id}, event, %DungeonCrawl.Player.Location{} = sender) do
+    case program_contexts do
+      %{^map_tile_id => %{program: program, object: object}} ->
+        %Runner{program: program, object: object, state: state} = Scripting.Runner.run(%Runner{program: program, object: object, state: state}, event)
+                                  |> Map.put(:event_sender, sender)
+                                  |> handle_broadcasting()
+        if program.status == :dead do
+          %Instances{ state | program_contexts: Map.delete(program_contexts, map_tile_id)}
+        else
+          updated_program_context = %{program: program, object: object, event_sender: sender}
+          %Instances{ state | program_contexts: Map.put(program_contexts, map_tile_id, updated_program_context)}
+        end
+
+      _ ->
+        state
+    end
+  end
+
+  @doc """
+  Creates the given map tile in the parent instance state if it does not already exist.
+  Returns a tuple containing the created (or already existing) tile, and the updated (or same) state.
+  Does not update `dirty_ids` since this tile should already exist in the DB for it to have an id.
+  """
+  def create_map_tile(%Instances{} = state, map_tile) do
+    map_tile = case TileState.Parser.parse(map_tile.state) do
+                 {:ok, state} -> Map.put(map_tile, :parsed_state, state)
+                 _            -> map_tile
+               end
+    {map_tile, state} = _register_map_tile(state, map_tile)
+    case Scripting.Parser.parse(map_tile.script) do
+     {:ok, program} ->
+       unless program.status == :dead do
+         {map_tile, _start_program(state, map_tile.id, %{program: program, object: map_tile, event_sender: nil})}
+       else
+         {map_tile, state}
+       end
+     other ->
+       Logger.warn """
+                   Possible corrupt script for map tile instance: #{inspect map_tile}
+                   Not :ok response: #{inspect other}
+                   """
+       {map_tile, state}
+    end
+  end
+
+  defp _register_map_tile(%Instances{map_by_ids: by_id, map_by_coords: by_coords} = state, map_tile) do
+     if Map.has_key?(by_id, map_tile.id) do
+      # Tile already registered
+      {by_id[map_tile.id], state}
+    else
+      z_index_map = by_coords[{map_tile.row, map_tile.col}] || %{}
+      if Map.has_key?(z_index_map, map_tile.z_index) do
+        # don't overwrite and add the tile if there's already one registered there
+        {by_id[z_index_map[map_tile.z_index]], state}
+      else
+        by_id = Map.put(by_id, map_tile.id, map_tile)
+        by_coords = Map.put(by_coords, {map_tile.row, map_tile.col},
+                            Map.put(z_index_map, map_tile.z_index, map_tile.id))
+        {map_tile, %Instances{ state | map_by_ids: by_id, map_by_coords: by_coords }}
+      end
+    end
+  end
+
+  defp _start_program(%Instances{program_contexts: program_contexts} = state, map_tile_id, program_context) do
+    if Map.has_key?(program_contexts, map_tile_id) do
+      # already a running program for that tile id, or there is no map tile for that id
+      state
+    else
+      %Instances{ state | program_contexts: Map.put(program_contexts, map_tile_id, program_context)}
+    end
+  end
+
+  @doc """
+  Updates the given map tile in the parent instance process, and returns the updated tile and new state
+  """
+  def update_map_tile(%Instances{map_by_ids: by_id, map_by_coords: by_coords} = state, %{id: map_tile_id}, new_attributes) do
+    new_attributes = Map.delete(new_attributes, :id)
+    previous_changeset = state.dirty_ids[map_tile_id] || MapTile.changeset(by_id[map_tile_id], %{})
+
+    updated_tile = by_id[map_tile_id] |> Map.merge(new_attributes)
+
+    old_tile_coords = Map.take(by_id[map_tile_id], [:row, :col, :z_index])
+    updated_tile_coords = Map.take(updated_tile, [:row, :col, :z_index])
+
+    by_id = Map.put(by_id, map_tile_id, updated_tile)
+    dirty_ids = Map.put(state.dirty_ids, map_tile_id, MapTile.changeset(previous_changeset, new_attributes))
+
+    if updated_tile_coords != old_tile_coords do
+      z_index_map = by_coords[{updated_tile_coords.row, updated_tile_coords.col}] || %{}
+
+      if Map.has_key?(z_index_map, updated_tile_coords.z_index) do
+        # invalid update, just throw it away (or maybe raise an error instead of silently doing nothing)
+        {nil, state}
+      else
+        by_coords = _remove_coord(by_coords, Map.take(old_tile_coords, [:row, :col, :z_index]))
+                    |> _put_coord(Map.take(updated_tile_coords, [:row, :col, :z_index]), map_tile_id)
+        {updated_tile, %Instances{ state | map_by_ids: by_id, map_by_coords: by_coords, dirty_ids: dirty_ids }}
+      end
+    else
+      {updated_tile, %Instances{ state | map_by_ids: by_id, dirty_ids: dirty_ids }}
+    end
+  end
+
+  @doc """
+  Deletes the given map tile from the instance state.
+  Returns a tuple containing the deleted tile (nil if no tile was deleted) and the updated state.
+  """
+  def delete_map_tile(%Instances{program_contexts: program_contexts, map_by_ids: by_id, map_by_coords: by_coords} = state, %{id: map_tile_id}) do
+    program_contexts = Map.delete(program_contexts, map_tile_id)
+    dirty_ids = Map.put(state.dirty_ids, map_tile_id, :deleted)
+
+    map_tile = by_id[map_tile_id]
+
+    if map_tile do
+      by_coords = _remove_coord(by_coords, Map.take(map_tile, [:row, :col, :z_index]))
+      by_id = Map.delete(by_id, map_tile_id)
+      {map_tile, %Instances{ program_contexts: program_contexts, map_by_ids: by_id, map_by_coords: by_coords, dirty_ids: dirty_ids }}
+    else
+      {nil, state}
+    end
+  end
+
+  @doc """
+  Takes a program context, and sends all queued up broadcasts. Returns the context with broadcast queues emtpied.
+  """
+  def handle_broadcasting(runner_context) do
+    _handle_broadcasts(runner_context.program.broadcasts, "dungeons:#{runner_context.object.map_instance_id}")
+    _handle_broadcasts(runner_context.program.responses, runner_context.event_sender)
+    %{ runner_context | program: %{ runner_context.program | responses: [], broadcasts: [] } }
+  end
+
+  defp _handle_broadcasts([ [event, payload] | messages], socket) when is_binary(socket) do
+    DungeonCrawlWeb.Endpoint.broadcast socket, event, payload
+    _handle_broadcasts(messages, socket)
+  end
+  defp _handle_broadcasts([message | messages], player_location = %DungeonCrawl.Player.Location{}) do
+    DungeonCrawlWeb.Endpoint.broadcast "players:#{player_location.id}", "message", %{message: message}
+    _handle_broadcasts(messages, player_location)
+  end
+  defp _handle_broadcasts(_, _), do: nil
+
+  @directions %{
+    "up"    => {-1,  0},
+    "down"  => { 1,  0},
+    "left"  => { 0, -1},
+    "right" => { 0,  1},
+    "north" => {-1,  0},
+    "south" => { 1,  0},
+    "west"  => { 0, -1},
+    "east"  => { 0,  1}
+  }
+
+  @no_direction { 0,  0}
+
+  defp _direction_delta(direction) do
+    @directions[direction] || @no_direction
+  end
+
+  defp _remove_coord(by_coords, %{row: row, col: col, z_index: z_index}) do
+    z_indexes = case Map.fetch(by_coords, {row, col}) do
+                  {:ok, z_index_map} -> Map.delete(z_index_map, z_index)
+                  _                  -> %{}
+                end
+    Map.put(by_coords, {row, col}, z_indexes)
+  end
+
+  defp _put_coord(by_coords, %{row: row, col: col, z_index: z_index}, map_tile_id) do
+    z_indexes = case Map.fetch(by_coords, {row, col}) do
+                  {:ok, z_index_map} -> Map.put(z_index_map, z_index, map_tile_id)
+                  _                  -> %{z_index => map_tile_id}
+                end
+    Map.put(by_coords, {row, col}, z_indexes)
   end
 end
 

--- a/lib/dungeon_crawl/dungeon_processes/instances.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instances.ex
@@ -9,24 +9,24 @@ defmodule DungeonCrawl.DungeonProcesses.Instances do
   @doc """
   Gets the top map tile in the given directon from the provided coordinates.
   """
-  def get_map_tile(%{row: row, col: col} = map_tile, direction \\ nil, registry \\ DungeonInstanceRegistry) do
-    {:ok, instance} = InstanceRegistry.lookup_or_create(registry, map_tile.map_instance_id)
+  def get_map_tile(%{row: row, col: col} = map_tile, direction \\ nil) do
+    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, map_tile.map_instance_id)
     InstanceProcess.get_tile(instance, row, col, direction)
   end
 
   @doc """
   Gets the map tile given by the id.
   """
-  def get_map_tile_by_id(%{id: map_tile_id} = map_tile, registry \\ DungeonInstanceRegistry) do
-    {:ok, instance} = InstanceRegistry.lookup_or_create(registry, map_tile.map_instance_id)
+  def get_map_tile_by_id(%{id: map_tile_id} = map_tile) do
+    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, map_tile.map_instance_id)
     InstanceProcess.get_tile(instance, map_tile_id)
   end
 
   @doc """
   Updates the given map tile in the parent instance process, and returns the updated tile.
   """
-  def update_map_tile(map_tile, new_attrs, registry \\ DungeonInstanceRegistry) do
-    {:ok, instance} = InstanceRegistry.lookup_or_create(registry, map_tile.map_instance_id)
+  def update_map_tile(map_tile, new_attrs) do
+    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, map_tile.map_instance_id)
     InstanceProcess.update_tile(instance, map_tile.id, new_attrs)
     InstanceProcess.get_tile(instance, map_tile.id)
   end

--- a/lib/dungeon_crawl/dungeon_processes/instances.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instances.ex
@@ -1,0 +1,34 @@
+defmodule DungeonCrawl.DungeonProcesses.Instances do
+  @moduledoc """
+  The instances context. This wraps InstanceRegistry lookups and InstanceProcess methods
+  for convenience.
+  """
+
+  alias DungeonCrawl.DungeonProcesses.{InstanceRegistry,InstanceProcess}
+
+  @doc """
+  Gets the top map tile in the given directon from the provided coordinates.
+  """
+  def get_map_tile(%{row: row, col: col} = map_tile, direction \\ nil, registry \\ DungeonInstanceRegistry) do
+    {:ok, instance} = InstanceRegistry.lookup_or_create(registry, map_tile.map_instance_id)
+    InstanceProcess.get_tile(instance, row, col, direction)
+  end
+
+  @doc """
+  Gets the map tile given by the id.
+  """
+  def get_map_tile_by_id(%{id: map_tile_id} = map_tile, registry \\ DungeonInstanceRegistry) do
+    {:ok, instance} = InstanceRegistry.lookup_or_create(registry, map_tile.map_instance_id)
+    InstanceProcess.get_tile(instance, map_tile_id)
+  end
+
+  @doc """
+  Updates the given map tile in the parent instance process, and returns the updated tile.
+  """
+  def update_map_tile(map_tile, new_attrs, registry \\ DungeonInstanceRegistry) do
+    {:ok, instance} = InstanceRegistry.lookup_or_create(registry, map_tile.map_instance_id)
+    InstanceProcess.update_tile(instance, map_tile.id, new_attrs)
+    InstanceProcess.get_tile(instance, map_tile.id)
+  end
+end
+

--- a/lib/dungeon_crawl/player/player.ex
+++ b/lib/dungeon_crawl/player/player.ex
@@ -145,6 +145,14 @@ defmodule DungeonCrawl.Player do
              left_join: pmt in assoc(mt, :player_locations),
              select: count(pmt.id))
   end
+  # TODO: consolidate
+  def players_in_dungeon(%{instance_id: instance_id}) do
+    Repo.one(from m in DungeonCrawl.DungeonInstances.Map,
+             where: m.id == ^instance_id,
+             left_join: mt in assoc(m, :dungeon_map_tiles),
+             left_join: pmt in assoc(mt, :player_locations),
+             select: count(pmt.id))
+  end
 
   @doc """
   Returns the dungeon of the instance where the player location is.

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -3,6 +3,7 @@ defmodule DungeonCrawl.Scripting.Command do
   The various scripting commands available to a program.
   """
 
+  alias DungeonCrawl.Scripting
   alias DungeonCrawl.Scripting.Maths
   alias DungeonCrawl.TileState
   alias DungeonCrawl.TileTemplates
@@ -67,8 +68,14 @@ defmodule DungeonCrawl.Scripting.Command do
                    Map.put(Map.take(object, [:row, :col]), :rendering, DungeonCrawlWeb.SharedView.tile_and_style(object))
                ]}]
 
-    %{ program: %{program | broadcasts: [message | program.broadcasts] },
-       object: object}
+    if Map.has_key?(new_attrs, :script) do
+      {:ok, new_program} = Scripting.Parser.parse(new_attrs.script)
+      %{ program: %{new_program | broadcasts: [message | program.broadcasts], responses: program.responses, status: :idle },
+         object: object}
+    else
+      %{ program: %{program | broadcasts: [message | program.broadcasts] },
+         object: object}
+    end
   end
 
   @doc """

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -169,11 +169,11 @@ defmodule DungeonCrawl.Scripting.Command do
   If the movement is invalid, the `pc` will be set to the location of the `THUD` label if an active one exists.
 
   Valid directions:
-  n - North (up)
-  s - South (down)
-  e - East (right)
-  w - West (left)
-  i - Idle (no movement)
+  north - up
+  south - down
+  east  - right
+  west  - left
+  idle  - no movement
 
   ## Examples
 

--- a/lib/dungeon_crawl/scripting/program.ex
+++ b/lib/dungeon_crawl/scripting/program.ex
@@ -2,5 +2,5 @@ defmodule DungeonCrawl.Scripting.Program do
   @doc """
   A struct containing the representation of a program and its state.
   """
-  defstruct status: :dead, pc: 1, instructions: %{}, labels: %{}, locked: false, broadcasts: [], responses: []
+  defstruct status: :dead, pc: 1, instructions: %{}, labels: %{}, locked: false, broadcasts: [], responses: [], wait_cycles: 0
 end

--- a/lib/dungeon_crawl/scripting/program_validator.ex
+++ b/lib/dungeon_crawl/scripting/program_validator.ex
@@ -65,7 +65,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidator do
     _validate(program, instructions, ["Line #{line_no}: BECOME command params not being detected as kwargs `#{inspect params}`" | errors], user)
   end
 
-  defp _validate(program, [ {line_no, [ :if, [_condition, label] ]} | instructions], errors, user) do
+  defp _validate(program, [ {line_no, [ :jump_if, [_condition, label] ]} | instructions], errors, user) do
     if program.labels[label] do
       _validate(program, instructions, errors, user)
     else

--- a/lib/dungeon_crawl/scripting/program_validator.ex
+++ b/lib/dungeon_crawl/scripting/program_validator.ex
@@ -73,6 +73,18 @@ defmodule DungeonCrawl.Scripting.ProgramValidator do
     end
   end
 
+  defp _validate(program, [ {line_no, [:move, [direction] ]} | instructions], errors, user) do
+    _validate(program, [ {line_no, [:move, [direction, false] ]} | instructions], errors, user)
+  end
+
+  defp _validate(program, [ {line_no, [:move, [direction, _] ]} | instructions], errors, user) do
+    if ["north", "south", "west", "east", "up", "down", "left", "right", "idle"] |> Enum.member?(direction) do
+      _validate(program, instructions, errors, user)
+    else
+      _validate(program, instructions, ["Line #{line_no}: MOVE command references invalid direction `#{direction}`" | errors], user)
+    end
+  end
+
   defp _validate(program, [ _nothing_to_validate | instructions], errors, user) do
     _validate(program, instructions, errors, user)
   end

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -12,7 +12,7 @@ require Logger
       run(%{program: program, object: object})
     else
       _ ->
-        %{program: %{program | responses: [ "Label not in script: #{label}" | program.responses]}, object: object}
+        %{program: program, object: object}
     end
   end
 

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -3,7 +3,7 @@ defmodule DungeonCrawl.Scripting.Runner do
 
 require Logger
   @doc """
-  Run the program until encountering a stop marker. Returns the final state of the program.
+  Run the program one cycle. Returns the next state of the program.
   """
   def run(%{program: program, object: object, label: label}) do
     with [[next_pc, _]] <- program.labels[label] || [] |> Enum.filter(fn([_l,a]) -> a end) |> Enum.take(1),
@@ -30,9 +30,13 @@ Logger.info inspect object.state
         if program.pc > Enum.count(program.instructions) do
           %{program: %{program | pc: 0, status: :idle}, object: object}
         else
-          # for now keep running, later just return program state
-          run(%{program: program, object: object})
+          %{program: program, object: object}
         end
+
+      :wait ->
+        wait_cycles = program.wait_cycles - 1
+        status = if wait_cycles <= 0, do: :alive, else: program.status
+        %{program: %{program | wait_cycles: wait_cycles, status: status}, object: object}
 
       :idle ->
         %{program: program, object: object}

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -1,22 +1,27 @@
 defmodule DungeonCrawl.Scripting.Runner do
   alias DungeonCrawl.Scripting.Command
+  alias DungeonCrawl.Scripting.Runner
+  alias DungeonCrawl.Scripting.Program
+  alias DungeonCrawl.DungeonProcesses.Instances
+
+  defstruct program: %Program{}, object: %{}, state: %Instances{}, event_sender: nil
 
 require Logger
   @doc """
   Run the program one cycle. Returns the next state of the program.
   One cycle being until it hits a stop or wait condition.
   """
-  def run(%{program: program, object: object, label: label}) do
+  def run(runner_state = %Runner{program: program}, label) do
     with [[next_pc, _]] <- program.labels[label] || [] |> Enum.filter(fn([_l,a]) -> a end) |> Enum.take(1),
          program = %{program | pc: next_pc, status: :alive} do
-      run(%{program: program, object: object})
+      run(%Runner{ runner_state | program: program})
     else
       _ ->
-        %{program: program, object: object}
+        runner_state
     end
   end
 
-  def run(%{program: program, object: object}) do
+  def run(%Runner{program: program, object: object} = runner_state) do
     case program.status do
       :alive ->
         [command, params] = program.instructions[program.pc]
@@ -26,26 +31,26 @@ Logger.info inspect params
 Logger.info inspect object
 Logger.info inspect object.state
 Logger.info inspect object && object.state
-        %{program: program, object: object} = apply(Command, command, [%{program: program, object: object, params: params}])
+        runner_state = apply(Command, command, [runner_state, params])
 
         # increment program counter, check for end of program
-        program = %{program | pc: program.pc + 1}
+        program = %{runner_state.program | pc: runner_state.program.pc + 1}
         if program.pc > Enum.count(program.instructions) do
-          %{program: %{program | pc: 0, status: :idle}, object: object}
+          %{ runner_state | program: %{program | pc: 0, status: :idle} }
         else
-          run(%{program: program, object: object})
+          run( %{ runner_state | program: program } )
         end
 
       :wait ->
         wait_cycles = program.wait_cycles - 1
         status = if wait_cycles <= 0, do: :alive, else: program.status
-        %{program: %{program | wait_cycles: wait_cycles, status: status}, object: object}
+        %{ runner_state | program: %{program | wait_cycles: wait_cycles, status: status} }
 
       :idle ->
-        %{program: program, object: object}
+        runner_state
 
       :dead ->
-        %{program: program, object: object}
+        runner_state
     end
   end
 end

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -4,6 +4,7 @@ defmodule DungeonCrawl.Scripting.Runner do
 require Logger
   @doc """
   Run the program one cycle. Returns the next state of the program.
+  One cycle being until it hits a stop or wait condition.
   """
   def run(%{program: program, object: object, label: label}) do
     with [[next_pc, _]] <- program.labels[label] || [] |> Enum.filter(fn([_l,a]) -> a end) |> Enum.take(1),
@@ -30,7 +31,7 @@ Logger.info inspect object.state
         if program.pc > Enum.count(program.instructions) do
           %{program: %{program | pc: 0, status: :idle}, object: object}
         else
-          %{program: program, object: object}
+          run(%{program: program, object: object})
         end
 
       :wait ->

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -23,7 +23,9 @@ require Logger
 Logger.info "Running:"
 Logger.info inspect command
 Logger.info inspect params
+Logger.info inspect object
 Logger.info inspect object.state
+Logger.info inspect object && object.state
         %{program: program, object: object} = apply(Command, command, [%{program: program, object: object, params: params}])
 
         # increment program counter, check for end of program

--- a/lib/dungeon_crawl/tile_templates/tile_seeder.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder.ex
@@ -16,8 +16,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder do
     open_door    = create_with_defaults!(%{character: "'", name: "Open Door", description: "An open door", state: "blocking: false, open: true"})
     closed_door  = create_with_defaults!(%{character: "+", name: "Closed Door", description: "A closed door", state: "blocking: true, open: false"})
 
-    open_door   = Repo.update! TileTemplates.change_tile_template(open_door, %{script: ":CLOSE\n#BECOME TTID:#{closed_door.id}"})
-    closed_door = Repo.update! TileTemplates.change_tile_template(closed_door, %{script: ":OPEN\n#BECOME TTID:#{open_door.id}"})
+    open_door   = Repo.update! TileTemplates.change_tile_template(open_door, %{script: "#END\n:CLOSE\n#BECOME TTID:#{closed_door.id}"})
+    closed_door = Repo.update! TileTemplates.change_tile_template(closed_door, %{script: "#END\n:OPEN\n#BECOME TTID:#{open_door.id}"})
 
     solo_door() # placeholder for now
 

--- a/lib/dungeon_crawl_web/channels/dungeon_channel.ex
+++ b/lib/dungeon_crawl_web/channels/dungeon_channel.ex
@@ -12,6 +12,9 @@ defmodule DungeonCrawlWeb.DungeonChannel do
   def join("dungeons:" <> instance_id, _payload, socket) do
     instance_id = String.to_integer(instance_id)
 
+    # make sure the instance is up and running
+    InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, instance_id)
+
     {:ok, %{instance_id: instance_id}, assign(socket, :instance_id, instance_id)}
   end
 

--- a/lib/dungeon_crawl_web/channels/dungeon_channel.ex
+++ b/lib/dungeon_crawl_web/channels/dungeon_channel.ex
@@ -66,12 +66,14 @@ defmodule DungeonCrawlWeb.DungeonChannel do
     player_location = Player.get_location!(socket.assigns.user_id_hash) |> Repo.preload(:map_tile)
     target_tile = Dungeon.get_map_tile(player_location.map_tile, direction) |> Repo.preload(:tile_template)
 
-    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, socket.assigns.instance_id)
+    if target_tile do
+      {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, socket.assigns.instance_id)
 
-    InstanceProcess.send_event(instance, target_tile.id, action, player_location)
+      InstanceProcess.send_event(instance, target_tile.id, action, player_location)
 
-    if !InstanceProcess.responds_to_event?(instance, target_tile.id, action) && unhandled_event_message do
-      DungeonCrawlWeb.Endpoint.broadcast "players:#{player_location.id}", "message", %{message: unhandled_event_message}
+      if !InstanceProcess.responds_to_event?(instance, target_tile.id, action) && unhandled_event_message do
+        DungeonCrawlWeb.Endpoint.broadcast "players:#{player_location.id}", "message", %{message: unhandled_event_message}
+      end
     end
     {:noreply, socket}
   end

--- a/lib/dungeon_crawl_web/channels/dungeon_channel.ex
+++ b/lib/dungeon_crawl_web/channels/dungeon_channel.ex
@@ -75,21 +75,4 @@ defmodule DungeonCrawlWeb.DungeonChannel do
     end
     {:noreply, socket}
   end
-
-  defp _handle_broadcasts(_socket, []), do: nil
-  defp _handle_broadcasts(socket, [[event, payload] | broadcasts]) do
-    _handle_broadcasts(socket, broadcasts)
-    broadcast socket, event, payload
-  end
-
-  defp _reply_payload([]), do: :ok
-  defp _reply_payload([response | responses]) do
-    case _reply_payload(responses) do
-      {:error, %{msg: msgs}} ->
-        {:error, %{msg: "#{msgs}; #{response}"}}
-
-      _ ->
-        {:error, %{msg: response}}
-    end
-  end
 end

--- a/lib/dungeon_crawl_web/channels/dungeon_channel.ex
+++ b/lib/dungeon_crawl_web/channels/dungeon_channel.ex
@@ -5,6 +5,8 @@ defmodule DungeonCrawlWeb.DungeonChannel do
   alias DungeonCrawl.DungeonInstances, as: Dungeon
   alias DungeonCrawl.Action.{Move}
 
+  # TODO: what prevents someone from changing the instance_id to a dungeon they are not actually in (or allowed to be in)
+  # and evesdrop on broadcasts?
   def join("dungeons:" <> instance_id, _payload, socket) do
     instance_id = String.to_integer(instance_id)
 

--- a/lib/dungeon_crawl_web/channels/player_channel.ex
+++ b/lib/dungeon_crawl_web/channels/player_channel.ex
@@ -12,11 +12,4 @@ defmodule DungeonCrawlWeb.PlayerChannel do
   def handle_in("ping", payload, socket) do
     {:reply, {:ok, payload}, socket}
   end
-
-  # It is also common to receive messages from the client and
-  # broadcast to everyone in the current topic (dungeon:lobby).
-  def handle_in("shout", payload, socket) do
-    broadcast socket, "shout", payload
-    {:noreply, socket}
-  end
 end

--- a/lib/dungeon_crawl_web/channels/player_channel.ex
+++ b/lib/dungeon_crawl_web/channels/player_channel.ex
@@ -1,0 +1,22 @@
+defmodule DungeonCrawlWeb.PlayerChannel do
+  use DungeonCrawl.Web, :channel
+
+  alias DungeonCrawl.Player
+
+  def join("players:" <> location_id, _payload, socket) do
+    instance_id = String.to_integer(location_id)
+
+    {:ok, %{location_id: location_id}, assign(socket, :location_id, location_id)}
+  end
+
+  def handle_in("ping", payload, socket) do
+    {:reply, {:ok, payload}, socket}
+  end
+
+  # It is also common to receive messages from the client and
+  # broadcast to everyone in the current topic (dungeon:lobby).
+  def handle_in("shout", payload, socket) do
+    broadcast socket, "shout", payload
+    {:noreply, socket}
+  end
+end

--- a/lib/dungeon_crawl_web/channels/player_channel.ex
+++ b/lib/dungeon_crawl_web/channels/player_channel.ex
@@ -1,11 +1,8 @@
 defmodule DungeonCrawlWeb.PlayerChannel do
   use DungeonCrawl.Web, :channel
 
-  alias DungeonCrawl.Player
-
   def join("players:" <> location_id, _payload, socket) do
-    instance_id = String.to_integer(location_id)
-
+    # TODO: verify the player joining the channel is the player
     {:ok, %{location_id: location_id}, assign(socket, :location_id, location_id)}
   end
 

--- a/lib/dungeon_crawl_web/channels/user_socket.ex
+++ b/lib/dungeon_crawl_web/channels/user_socket.ex
@@ -4,6 +4,7 @@ defmodule DungeonCrawlWeb.UserSocket do
   ## Channels
   # channel "room:*", DungeonCrawlWeb.RoomChannel
   channel "dungeons:*", DungeonCrawlWeb.DungeonChannel
+  channel "players:*", DungeonCrawlWeb.PlayerChannel
 
   ## Transports
   # transport :websocket, Phoenix.Transports.WebSocket

--- a/lib/dungeon_crawl_web/controllers/crawler.ex
+++ b/lib/dungeon_crawl_web/controllers/crawler.ex
@@ -53,6 +53,11 @@ defmodule DungeonCrawlWeb.Crawler do
   """
   def leave_and_broadcast(%Player.Location{} = location) do
     deleted_location = Player.delete_location!(location)
+
+    if Player.players_in_dungeon(%{instance_id: deleted_location.map_tile.map_instance_id}) == 0 do
+      DungeonCrawl.DungeonProcesses.InstanceRegistry.remove(DungeonInstanceRegistry, deleted_location.map_tile.map_instance_id)
+    end
+
     _broadcast_leave_event(deleted_location)
     deleted_location
   end

--- a/lib/dungeon_crawl_web/controllers/crawler.ex
+++ b/lib/dungeon_crawl_web/controllers/crawler.ex
@@ -1,6 +1,9 @@
 defmodule DungeonCrawlWeb.Crawler do
   alias DungeonCrawl.Dungeon
   alias DungeonCrawl.DungeonInstances
+  alias DungeonCrawl.DungeonProcesses.InstanceProcess
+  alias DungeonCrawl.DungeonProcesses.InstanceRegistry
+  alias DungeonCrawl.DungeonProcesses.Instances
   alias DungeonCrawl.Player
   alias DungeonCrawl.Repo
 
@@ -22,7 +25,7 @@ defmodule DungeonCrawlWeb.Crawler do
   def join_and_broadcast(%DungeonInstances.Map{} = where, user_id_hash) do
     {:ok, location} = Player.create_location_on_empty_space(where, user_id_hash)
 
-     _broadcast_join_event(Repo.preload(location, [map_tile: :tile_template]))
+     _broadcast_join_event(Repo.preload(location, :map_tile))
      location
   end
 
@@ -33,14 +36,19 @@ defmodule DungeonCrawlWeb.Crawler do
   end
 
   defp _broadcast_join_event(location) do
-    top = DungeonInstances.get_map_tile(location.map_tile)
-    tile = if top, do: DungeonCrawlWeb.SharedView.tile_and_style(top), else: ""
+    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, location.map_tile.map_instance_id)
+    
+    InstanceProcess.run_with(instance, fn (instance_state) ->
+      {top, instance_state} = Instances.create_map_tile(instance_state, location.map_tile)
+      tile = if top, do: DungeonCrawlWeb.SharedView.tile_and_style(top), else: ""
 #    DungeonCrawlWeb.Endpoint.broadcast("dungeons:#{location.map_tile.map_instance_id}",
 #                                    "player_joined",
 #                                    %{row: top.row, col: top.col, tile: tile})
-    DungeonCrawlWeb.Endpoint.broadcast("dungeons:#{location.map_tile.map_instance_id}",
-                                    "tile_changes",
-                                    %{ tiles: [%{row: top.row, col: top.col, rendering: tile}] })
+      DungeonCrawlWeb.Endpoint.broadcast("dungeons:#{location.map_tile.map_instance_id}",
+                                      "tile_changes",
+                                      %{ tiles: [%{row: top.row, col: top.col, rendering: tile}] })
+      {tile, instance_state}
+    end)
   end
 
   @doc """
@@ -52,18 +60,26 @@ defmodule DungeonCrawlWeb.Crawler do
       %Player.Location{}
   """
   def leave_and_broadcast(%Player.Location{} = location) do
-    deleted_location = Player.delete_location!(location)
+    map_tile = Repo.preload(location, :map_tile).map_tile
+    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, map_tile.map_instance_id)
+    deleted_location = InstanceProcess.run_with(instance, fn (instance_state) ->
+      {_, instance_state} = Instances.delete_map_tile(instance_state, map_tile)
+      deleted_location = Player.delete_location!(location)
+
+      _broadcast_leave_event(instance_state, deleted_location)
+
+      {deleted_location, instance_state}
+    end)
 
     if Player.players_in_dungeon(%{instance_id: deleted_location.map_tile.map_instance_id}) == 0 do
-      DungeonCrawl.DungeonProcesses.InstanceRegistry.remove(DungeonInstanceRegistry, deleted_location.map_tile.map_instance_id)
+      InstanceRegistry.remove(DungeonInstanceRegistry, deleted_location.map_tile.map_instance_id)
     end
 
-    _broadcast_leave_event(deleted_location)
     deleted_location
   end
 
-  defp _broadcast_leave_event(location) do
-    top = DungeonInstances.get_map_tile(location.map_tile)
+  defp _broadcast_leave_event(instance_state, location) do
+    top = Instances.get_map_tile(instance_state, location.map_tile)
     tile = if top, do: DungeonCrawlWeb.SharedView.tile_and_style(top), else: ""
 #    DungeonCrawlWeb.Endpoint.broadcast("dungeons:#{location.map_tile.map_instance_id}",
 #                                    "player_left",

--- a/lib/dungeon_crawl_web/controllers/crawler_controller.ex
+++ b/lib/dungeon_crawl_web/controllers/crawler_controller.ex
@@ -83,7 +83,8 @@ defmodule DungeonCrawlWeb.CrawlerController do
 
   defp assign_player_location(conn, _opts) do
     player_location = Player.get_location(conn.assigns[:user_id_hash])
-                      |> Repo.preload(map_tile: [:dungeon, dungeon: [dungeon_map_tiles: :tile_template]])
+                      |> Repo.preload(map_tile: [:dungeon])
+
     conn
     |> assign(:player_location, player_location)
   end

--- a/lib/dungeon_crawl_web/templates/crawler/show.html.eex
+++ b/lib/dungeon_crawl_web/templates/crawler/show.html.eex
@@ -2,7 +2,7 @@
 <div class="text-center">
 <pre id="short_comm">Move...</pre>
 <input id="player" type="hidden" data-location-id="<%= @player_location.id %>" />
-<%= render(DungeonCrawlWeb.SharedView, "dungeon.html", dungeon: @player_location.map_tile.dungeon, readonly: false, with_template_id: false) %>
+<%= render(DungeonCrawlWeb.SharedView, "dungeon_instance.html", dungeon: @player_location.map_tile.dungeon, readonly: false, with_template_id: false) %>
 <br/>
 <%= link "Leave Dungeon", to: Routes.crawler_path(@conn, :destroy), method: :delete, data: [confirm: "No going back, are you sure?"], class: "btn btn-danger btn-xs" %>
 </div>

--- a/lib/dungeon_crawl_web/templates/crawler/show.html.eex
+++ b/lib/dungeon_crawl_web/templates/crawler/show.html.eex
@@ -2,7 +2,13 @@
 <div class="text-center">
 <pre id="short_comm">Move...</pre>
 <input id="player" type="hidden" data-location-id="<%= @player_location.id %>" />
-<%= render(DungeonCrawlWeb.SharedView, "dungeon_instance.html", dungeon: @player_location.map_tile.dungeon, readonly: false, with_template_id: false) %>
+<%= render(DungeonCrawlWeb.SharedView,
+           "dungeon_instance.html",
+           dungeon: @player_location.map_tile.dungeon, # Make this the instance
+           height: @player_location.map_tile.dungeon.height,
+           width: @player_location.map_tile.dungeon.width,
+           readonly: false,
+           with_template_id: false) %>
 <br/>
 <%= link "Leave Dungeon", to: Routes.crawler_path(@conn, :destroy), method: :delete, data: [confirm: "No going back, are you sure?"], class: "btn btn-danger btn-xs" %>
 </div>

--- a/lib/dungeon_crawl_web/templates/crawler/show.html.eex
+++ b/lib/dungeon_crawl_web/templates/crawler/show.html.eex
@@ -1,6 +1,7 @@
 <%= if @player_location do %>
 <div class="text-center">
 <pre id="short_comm">Move...</pre>
+<input id="player" type="hidden" data-location-id="<%= @player_location.id %>" />
 <%= render(DungeonCrawlWeb.SharedView, "dungeon.html", dungeon: @player_location.map_tile.dungeon, readonly: false, with_template_id: false) %>
 <br/>
 <%= link "Leave Dungeon", to: Routes.crawler_path(@conn, :destroy), method: :delete, data: [confirm: "No going back, are you sure?"], class: "btn btn-danger btn-xs" %>

--- a/lib/dungeon_crawl_web/templates/manage_dungeon/show.html.eex
+++ b/lib/dungeon_crawl_web/templates/manage_dungeon/show.html.eex
@@ -25,9 +25,21 @@
 
 <div class="text-center">
 <%= if @instance do %>
-<%= render(DungeonCrawlWeb.SharedView, "dungeon_instance.html", dungeon: @instance, readonly: true, with_template_id: false) %>
+<%= render(DungeonCrawlWeb.SharedView,
+           "dungeon_instance.html",
+           dungeon: @instance,
+           width: @instance.width,
+           height: @instance.height,
+           readonly: true,
+           with_template_id: false) %>
 <% else %>
-<%= render(DungeonCrawlWeb.SharedView, "dungeon.html", dungeon: @dungeon, readonly: true, with_template_id: false) %>
+<%= render(DungeonCrawlWeb.SharedView,
+           "dungeon.html",
+           dungeon: @dungeon,
+           width: @dungeon.width,
+           height: @dungeon.height,
+           readonly: true,
+           with_template_id: false) %>
 <% end %>
 </div>
 

--- a/lib/dungeon_crawl_web/templates/manage_dungeon/show.html.eex
+++ b/lib/dungeon_crawl_web/templates/manage_dungeon/show.html.eex
@@ -25,7 +25,7 @@
 
 <div class="text-center">
 <%= if @instance do %>
-<%= render(DungeonCrawlWeb.SharedView, "dungeon.html", dungeon: @instance, readonly: true, with_template_id: false) %>
+<%= render(DungeonCrawlWeb.SharedView, "dungeon_instance.html", dungeon: @instance, readonly: true, with_template_id: false) %>
 <% else %>
 <%= render(DungeonCrawlWeb.SharedView, "dungeon.html", dungeon: @dungeon, readonly: true, with_template_id: false) %>
 <% end %>

--- a/lib/dungeon_crawl_web/templates/shared/dungeon.html.eex
+++ b/lib/dungeon_crawl_web/templates/shared/dungeon.html.eex
@@ -1,6 +1,6 @@
 <pre class="dungeon_preview">
 <table id="dungeon" data-dungeon-id="<%= @dungeon.id %>" data-readonly="<%= @readonly %>">
-<%= {:safe, dungeon_as_table(@dungeon, @with_template_id) } %>
+<%= {:safe, dungeon_as_table(@dungeon, @dungeon.width, @dungeon.height, @with_template_id) } %>
 </table>
 </pre>
 

--- a/lib/dungeon_crawl_web/templates/shared/dungeon_instance.html.eex
+++ b/lib/dungeon_crawl_web/templates/shared/dungeon_instance.html.eex
@@ -1,6 +1,6 @@
 <pre class="dungeon_preview">
 <table id="dungeon_instance" data-instance-id="<%= @dungeon.id %>" data-readonly="<%= @readonly %>">
-<%= {:safe, dungeon_as_table(@dungeon, @with_template_id) } %>
+<%= {:safe, dungeon_as_table(@dungeon, @width, @height, @with_template_id) } %>
 </table>
 </pre>
 

--- a/lib/dungeon_crawl_web/templates/shared/dungeon_instance.html.eex
+++ b/lib/dungeon_crawl_web/templates/shared/dungeon_instance.html.eex
@@ -1,5 +1,5 @@
 <pre class="dungeon_preview">
-<table id="dungeon" data-dungeon-id="<%= @dungeon.id %>" data-readonly="<%= @readonly %>">
+<table id="dungeon_instance" data-instance-id="<%= @dungeon.id %>" data-readonly="<%= @readonly %>">
 <%= {:safe, dungeon_as_table(@dungeon, @with_template_id) } %>
 </table>
 </pre>

--- a/lib/dungeon_crawl_web/views/shared_view.ex
+++ b/lib/dungeon_crawl_web/views/shared_view.ex
@@ -1,12 +1,34 @@
 defmodule DungeonCrawlWeb.SharedView do
   use DungeonCrawl.Web, :view
 
-  def dungeon_as_table(dungeon, with_template_id \\ false) do
+  alias DungeonCrawl.DungeonProcesses.{InstanceRegistry, InstanceProcess}
+  alias DungeonCrawl.Dungeon
+  alias DungeonCrawl.DungeonInstances
+
+  def dungeon_as_table(dungeon, height, width, with_template_id \\ false) do
+    _dungeon_as_table(dungeon, height, width, with_template_id)
+  end
+
+  defp _dungeon_as_table(%Dungeon.Map{} = dungeon, height, width, with_template_id) do
     dungeon.dungeon_map_tiles
+    |> _dungeon_table(height, width, with_template_id)
+  end
+
+  defp _dungeon_as_table(%DungeonInstances.Map{} = dungeon, height, width, with_template_id) do
+    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, dungeon.id)
+    instance_state = InstanceProcess.get_state(instance)
+
+    instance_state.map_by_ids
+    |> Enum.map(fn({_id, map_tile}) -> map_tile end)
+    |> _dungeon_table(height, width, with_template_id)
+  end
+
+  defp _dungeon_table(dungeon_map_tiles, height, width, with_template_id) do
+    dungeon_map_tiles
     |> Enum.sort(fn(a,b) -> a.z_index > b.z_index end)
     |> DungeonCrawl.Repo.preload(:tile_template)
     |> Enum.reduce(%{}, fn(dmt,acc) -> if Map.has_key?(acc, {dmt.row, dmt.col}), do: acc, else: Map.put(acc, {dmt.row, dmt.col}, dmt) end)
-    |> rows(dungeon.height, dungeon.width, with_template_id)
+    |> rows(height, width, with_template_id)
   end
 
   defp rows(map, height, width, with_template_id) do

--- a/test/dungeon_crawl/action/move_test.exs
+++ b/test/dungeon_crawl/action/move_test.exs
@@ -24,6 +24,24 @@ defmodule DungeonCrawl.Action.MoveTest do
                                                        floor_b]
   end
 
+  test "moving to an empty floor space from a non map tile" do
+    floor_tt = insert_tile_template() # floor by default
+    dungeon = insert_stubbed_dungeon_instance()
+    floor_a = Dungeon.create_map_tile!(%{map_instance_id: dungeon.id, row: 1, col: 2, tile_template_id: floor_tt.id, state: floor_tt.state})
+    floor_b = Dungeon.create_map_tile!(%{map_instance_id: dungeon.id, row: 1, col: 1, tile_template_id: floor_tt.id, state: floor_tt.state})
+
+    player_location = insert_player_location(%{map_instance_id: dungeon.id, row: 2, col: 1}) |> Repo.preload(:map_tile)
+
+    destination = Dungeon.get_map_tile(dungeon.id, 1, 1)
+
+    assert {:ok, %{new_location: new_location, old_location: old_location}} = Move.go(player_location.map_tile, destination)
+    assert %MapTile{row: 2, col: 1} = old_location
+    assert %MapTile{row: 1, col: 1} = new_location
+    assert Dungeon.get_map_tiles(dungeon.id, 1, 2) == [floor_a]
+    assert Dungeon.get_map_tiles(dungeon.id, 1, 1) == [Repo.preload(player_location, :map_tile, force: true).map_tile,
+                                                       floor_b]
+  end
+
   test "moving to a bad space" do
     impassable_floor = insert_tile_template(%{responders: "{}", state: "blocking: true"})
 

--- a/test/dungeon_crawl/dungeon_instances/dungeon_instances_test.exs
+++ b/test/dungeon_crawl/dungeon_instances/dungeon_instances_test.exs
@@ -60,11 +60,6 @@ defmodule DungeonCrawl.DungeonInstancesTest do
       map_tile
     end
 
-    test "get_map_tile!/1 returns the map_tile with given id" do
-      map_tile = map_tile_fixture()
-      assert DungeonInstances.get_map_tile!(map_tile.id) == map_tile
-    end
-
     test "create_map_tile/1 with valid data creates a map_tile" do
       other_map_tile = map_tile_fixture()
       assert {:ok, %MapTile{} = _map_tile} = DungeonInstances.create_map_tile(Map.merge @valid_attrs, Map.take(other_map_tile, [:map_instance_id, :tile_template_id]))
@@ -74,101 +69,25 @@ defmodule DungeonCrawl.DungeonInstancesTest do
       assert {:error, %Ecto.Changeset{}} = DungeonInstances.create_map_tile(@invalid_attrs)
     end
 
-    test "update_map_tile/2 with valid data updates the map_tile" do
-      map_tile = map_tile_fixture()
-      tile_template = insert_tile_template()
-      old_tile_template = map_tile.tile_template_id
-      assert {:ok, map_tile} = DungeonInstances.update_map_tile(map_tile, %{tile_template_id: tile_template.id})
-      assert %MapTile{} = map_tile
-      refute old_tile_template == map_tile.tile_template_id
+    test "update_map_tiles/1 updates valid changes" do
+      map_tile_1 = map_tile_fixture(%{character: "0"})
+      {:ok, map_tile_2} = DungeonInstances.create_map_tile(Map.merge @valid_attrs, Map.take(map_tile_1, [:character, :map_instance_id, :tile_template_id]))
+
+      good_changeset = MapTile.changeset(map_tile_1, %{character: "Y"})
+      bad_changeset = MapTile.changeset(map_tile_2, %{character: "XXX", color: "red"})
+
+      assert {:ok, %{map_tile_updates: 2}} = DungeonInstances.update_map_tiles([good_changeset, bad_changeset])
+      assert "Y" == Repo.get(MapTile, map_tile_1.id).character
+      refute "XXX" == Repo.get(MapTile, map_tile_2.id).character
     end
 
-    test "update_map_tile/2 with invalid data returns error changeset" do
-      map_tile = map_tile_fixture()
-      assert {:error, %Ecto.Changeset{}} = DungeonInstances.update_map_tile(map_tile, @invalid_attrs)
-      assert map_tile == DungeonInstances.get_map_tile!(map_tile.id)
-    end
+    test "delete_map_tiles/1 deletes the map tiles with given ids" do
+      map_tile_1 = map_tile_fixture(%{character: "0"})
+      {:ok, map_tile_2} = DungeonInstances.create_map_tile(Map.merge @valid_attrs, Map.take(map_tile_1, [:character, :map_instance_id, :tile_template_id]))
 
-    test "get_map_tile/1 returns a map_tile from the top" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tile(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row, col: map_tile.col}) == map_tile
-      refute DungeonInstances.get_map_tile(%{map_instance_id: map_tile.map_instance_id+1, row: map_tile.row, col: map_tile.col})
-    end
-
-    test "get_map_tile/2 returns a map_tile from the top in the given direction" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tile(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row+1, col: map_tile.col},   "up") == map_tile
-      assert DungeonInstances.get_map_tile(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row-1, col: map_tile.col},   "down") == map_tile
-      assert DungeonInstances.get_map_tile(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row,   col: map_tile.col+1}, "left") == map_tile
-      assert DungeonInstances.get_map_tile(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row,   col: map_tile.col-1}, "right") == map_tile
-    end
-
-    test "get_map_tile/3 returns a map_tile" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tile(map_tile.map_instance_id, map_tile.row, map_tile.col) == map_tile
-      refute DungeonInstances.get_map_tile(map_tile.map_instance_id + 1, map_tile.row, map_tile.col)
-    end
-
-    test "get_map_tile/4 returns a map tile in the given direction" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tile(map_tile.map_instance_id, map_tile.row+1, map_tile.col,   "up") == map_tile
-      assert DungeonInstances.get_map_tile(map_tile.map_instance_id, map_tile.row-1, map_tile.col,   "down") == map_tile
-      assert DungeonInstances.get_map_tile(map_tile.map_instance_id, map_tile.row,   map_tile.col+1, "left") == map_tile
-      assert DungeonInstances.get_map_tile(map_tile.map_instance_id, map_tile.row,   map_tile.col-1, "right") == map_tile
-    end
-
-    test "get_map_tile!/2 returns a map tile in the given direction" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tile!(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row+1, col: map_tile.col},   "up") == map_tile
-      assert DungeonInstances.get_map_tile!(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row-1, col: map_tile.col},   "down") == map_tile
-      assert DungeonInstances.get_map_tile!(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row,   col: map_tile.col+1}, "left") == map_tile
-      assert DungeonInstances.get_map_tile!(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row,   col: map_tile.col-1}, "right") == map_tile
-    end
-
-    test "get_map_tile!/4 returns a map tile in the given direction" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tile!(map_tile.map_instance_id, map_tile.row+1, map_tile.col,   "up") == map_tile
-      assert DungeonInstances.get_map_tile!(map_tile.map_instance_id, map_tile.row-1, map_tile.col,   "down") == map_tile
-      assert DungeonInstances.get_map_tile!(map_tile.map_instance_id, map_tile.row,   map_tile.col+1, "left") == map_tile
-      assert DungeonInstances.get_map_tile!(map_tile.map_instance_id, map_tile.row,   map_tile.col-1, "right") == map_tile
-    end
-
-    test "get_map_tiles/1 returns a map_tile from the top" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tiles(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row, col: map_tile.col}) == [map_tile, bottom_tile]
-      assert DungeonInstances.get_map_tiles(%{map_instance_id: map_tile.map_instance_id+1, row: map_tile.row, col: map_tile.col}) == []
-    end
-
-    test "get_map_tiles/2 returns a map_tile from the top in the given direction" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tiles(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row+1, col: map_tile.col},   "up") == [map_tile, bottom_tile]
-      assert DungeonInstances.get_map_tiles(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row-1, col: map_tile.col},   "down") == [map_tile, bottom_tile]
-      assert DungeonInstances.get_map_tiles(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row,   col: map_tile.col+1}, "left") == [map_tile, bottom_tile]
-      assert DungeonInstances.get_map_tiles(%{map_instance_id: map_tile.map_instance_id, row: map_tile.row,   col: map_tile.col-1}, "right") == [map_tile, bottom_tile]
-    end
-
-    test "get_map_tiles/3 returns a map_tile" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tiles(map_tile.map_instance_id, map_tile.row, map_tile.col) == [map_tile, bottom_tile]
-      assert DungeonInstances.get_map_tiles(map_tile.map_instance_id + 1, map_tile.row, map_tile.col) == []
-    end
-
-    test "get_map_tiles/4 returns a map tile in the given direction" do
-      bottom_tile = map_tile_fixture()
-      map_tile = map_tile_fixture(%{z_index: 1}, bottom_tile.map_instance_id)
-      assert DungeonInstances.get_map_tiles(map_tile.map_instance_id, map_tile.row+1, map_tile.col,   "up") == [map_tile, bottom_tile]
-      assert DungeonInstances.get_map_tiles(map_tile.map_instance_id, map_tile.row-1, map_tile.col,   "down") == [map_tile, bottom_tile]
-      assert DungeonInstances.get_map_tiles(map_tile.map_instance_id, map_tile.row,   map_tile.col+1, "left") == [map_tile, bottom_tile]
-      assert DungeonInstances.get_map_tiles(map_tile.map_instance_id, map_tile.row,   map_tile.col-1, "right") == [map_tile, bottom_tile]
+      assert {1, nil} = DungeonInstances.delete_map_tiles([map_tile_1.id])
+      refute Repo.get(MapTile, map_tile_1.id)
+      assert Repo.get(MapTile, map_tile_2.id)
     end
   end
 end

--- a/test/dungeon_crawl/dungeon_processes/instance_process_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_process_test.exs
@@ -1,0 +1,31 @@
+defmodule DungeonCrawl.InstanceProcessTest do
+  use DungeonCrawl.DataCase
+
+  alias DungeonCrawl.DungeonProcesses.InstanceProcess
+  alias DungeonCrawl.Scripting.Program
+
+  setup do
+    {:ok, instance_process} = InstanceProcess.start_link([])
+    %{instance_process: instance_process}
+  end
+
+  test "load_map", %{instance_process: instance_process} do
+
+  end
+
+  test "start_scheduler", %{instance_process: instance_process} do
+
+  end
+
+  test "inspect_state", %{instance_process: instance_process} do
+
+  end
+
+  test "send_event", %{instance_process: instance_process} do
+
+  end
+
+  test "responds_to_event?", %{instance_process: instance_process} do
+
+  end
+end

--- a/test/dungeon_crawl/dungeon_processes/instance_process_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_process_test.exs
@@ -1,31 +1,101 @@
 defmodule DungeonCrawl.InstanceProcessTest do
   use DungeonCrawl.DataCase
 
+  import ExUnit.CaptureLog
+
   alias DungeonCrawl.DungeonProcesses.InstanceProcess
   alias DungeonCrawl.Scripting.Program
+  alias DungeonCrawl.DungeonInstances.MapTile
+  alias DungeonCrawl.Player.Location
 
   setup do
     {:ok, instance_process} = InstanceProcess.start_link([])
-    %{instance_process: instance_process}
+    tt = insert_tile_template()
+    map_instance = insert_stubbed_dungeon_instance(
+                     %{},
+                     [%MapTile{character: "O", row: 1, col: 1, z_index: 0, script: "#END\n:TOUCH\nHey\n#END\n:TERMINATE\n#DIE", tile_template_id: tt.id}])
+    map_tile = DungeonCrawl.Repo.get_by(MapTile, %{map_instance_id: map_instance.id})
+
+    InstanceProcess.load_map(instance_process, [map_tile])
+
+    %{instance_process: instance_process, map_tile_id: map_tile.id}
   end
 
-  test "load_map", %{instance_process: instance_process} do
+  test "load_map", %{instance_process: instance_process, map_tile_id: map_tile_id} do
+    map_tile_with_script = %MapTile{id: 236, character: "O", row: 1, col: 1, z_index: 0, script: "#BECOME color: red"}
+    map_tiles = [%MapTile{id: 123, character: "O", row: 1, col: 2, z_index: 0},
+                 map_tile_with_script]
 
+    assert :ok = InstanceProcess.load_map(instance_process, map_tiles)
+
+    # Starts the program(s) for the tiles, no script nothing done for that tile.
+    assert { programs } = InstanceProcess.inspect_state(instance_process)
+    assert %{^map_tile_id => %{event_sender: nil,
+                       object: %MapTile{},
+                       program: %Program{status: :alive}},
+             236 => %{event_sender: nil,
+                       object: map_tile_with_script,
+                       program: %Program{status: :alive}}
+            } = programs
+
+    # Does not load a program overtop an already running program for that map_tile id
+    assert :ok = InstanceProcess.load_map(instance_process, [%MapTile{id: map_tile_id, script: "#DIE"}])
+    assert { programs } == InstanceProcess.inspect_state(instance_process)
+
+    # Does not load a corrupt script (edge case - corrupt script shouldnt even get into the DB, and logs a warning
+    assert capture_log(fn ->
+             assert :ok = InstanceProcess.load_map(instance_process, [%MapTile{id: 123, script: "#NOT_A_REAL_COMMAND"}])
+           end) =~ ~r/Possible corrupt script for map tile instance:/
+    assert { programs } == InstanceProcess.inspect_state(instance_process)
   end
 
   test "start_scheduler", %{instance_process: instance_process} do
-
+    # Starts the scheduler that will run every xxx ms and run the next parts of all the programs
+    InstanceProcess.start_scheduler(instance_process)
   end
 
-  test "inspect_state", %{instance_process: instance_process} do
-
+  test "inspect_state returns a listing of running programs", %{instance_process: instance_process, map_tile_id: map_tile_id} do
+    assert { programs } = InstanceProcess.inspect_state(instance_process)
+    assert %{^map_tile_id => %{event_sender: nil,
+                       object: %MapTile{},
+                       program: %Program{status: :alive}}
+            } = programs
   end
 
-  test "send_event", %{instance_process: instance_process} do
-
+  test "responds_to_event?", %{instance_process: instance_process, map_tile_id: map_tile_id} do
+    assert InstanceProcess.responds_to_event?(instance_process, map_tile_id, "TOUCH")
+    refute InstanceProcess.responds_to_event?(instance_process, map_tile_id, "SNIFF")
+    refute InstanceProcess.responds_to_event?(instance_process, map_tile_id-1, "ANYTHING")
   end
 
-  test "responds_to_event?", %{instance_process: instance_process} do
+  test "send_event", %{instance_process: instance_process, map_tile_id: map_tile_id} do
+    player_location = %Location{id: 555}
 
+    player_channel = "players:#{player_location.id}"
+    DungeonCrawlWeb.Endpoint.subscribe(player_channel)
+
+    { %{^map_tile_id => %{program: program} } } = InstanceProcess.inspect_state(instance_process)
+
+    # noop if it tile doesnt have a program
+    InstanceProcess.send_event(instance_process, 111, "TOUCH", player_location)
+    { %{^map_tile_id => %{program: same_program} } } = InstanceProcess.inspect_state(instance_process)
+    assert program == same_program
+
+    # it does something
+    InstanceProcess.send_event(instance_process, map_tile_id, "TOUCH", player_location)
+    { %{^map_tile_id => %{program: updated_program} } } = InstanceProcess.inspect_state(instance_process)
+    refute program == updated_program
+    assert_receive %Phoenix.Socket.Broadcast{
+            topic: ^player_channel,
+            event: "message",
+            payload: %{message: "Hey"}}
+
+    # prunes the program if died during the run of the label
+    InstanceProcess.send_event(instance_process, map_tile_id, "TERMINATE", player_location)
+    assert { %{} } = InstanceProcess.inspect_state(instance_process)
   end
+
+#  test "send_events", %{instance_process: instance_process} do
+#    Process.send(instance, :perform_actions)
+#  end
 end

--- a/test/dungeon_crawl/dungeon_processes/instance_process_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_process_test.exs
@@ -30,7 +30,7 @@ defmodule DungeonCrawl.InstanceProcessTest do
     assert :ok = InstanceProcess.load_map(instance_process, map_tiles)
 
     # Starts the program(s) for the tiles, no script nothing done for that tile.
-    assert { programs } = InstanceProcess.inspect_state(instance_process)
+    assert { programs, {by_id, by_coord} } = InstanceProcess.inspect_state(instance_process)
     assert %{^map_tile_id => %{event_sender: nil,
                        object: %MapTile{},
                        program: %Program{status: :alive}},
@@ -41,13 +41,13 @@ defmodule DungeonCrawl.InstanceProcessTest do
 
     # Does not load a program overtop an already running program for that map_tile id
     assert :ok = InstanceProcess.load_map(instance_process, [%MapTile{id: map_tile_id, script: "#DIE"}])
-    assert { programs } == InstanceProcess.inspect_state(instance_process)
+    assert { programs, {by_id, by_coord} } == InstanceProcess.inspect_state(instance_process)
 
     # Does not load a corrupt script (edge case - corrupt script shouldnt even get into the DB, and logs a warning
     assert capture_log(fn ->
              assert :ok = InstanceProcess.load_map(instance_process, [%MapTile{id: 123, script: "#NOT_A_REAL_COMMAND"}])
            end) =~ ~r/Possible corrupt script for map tile instance:/
-    assert { programs } == InstanceProcess.inspect_state(instance_process)
+    assert { programs, {by_id, by_coord} } == InstanceProcess.inspect_state(instance_process)
   end
 
   test "start_scheduler", %{instance_process: instance_process} do
@@ -56,7 +56,7 @@ defmodule DungeonCrawl.InstanceProcessTest do
   end
 
   test "inspect_state returns a listing of running programs", %{instance_process: instance_process, map_tile_id: map_tile_id} do
-    assert { programs } = InstanceProcess.inspect_state(instance_process)
+    assert { programs, {_, _} } = InstanceProcess.inspect_state(instance_process)
     assert %{^map_tile_id => %{event_sender: nil,
                        object: %MapTile{},
                        program: %Program{status: :alive}}
@@ -75,16 +75,16 @@ defmodule DungeonCrawl.InstanceProcessTest do
     player_channel = "players:#{player_location.id}"
     DungeonCrawlWeb.Endpoint.subscribe(player_channel)
 
-    { %{^map_tile_id => %{program: program} } } = InstanceProcess.inspect_state(instance_process)
+    { %{^map_tile_id => %{program: program} }, {_, _} } = InstanceProcess.inspect_state(instance_process)
 
     # noop if it tile doesnt have a program
     InstanceProcess.send_event(instance_process, 111, "TOUCH", player_location)
-    { %{^map_tile_id => %{program: same_program} } } = InstanceProcess.inspect_state(instance_process)
+    { %{^map_tile_id => %{program: same_program} }, {_, _} } = InstanceProcess.inspect_state(instance_process)
     assert program == same_program
 
     # it does something
     InstanceProcess.send_event(instance_process, map_tile_id, "TOUCH", player_location)
-    { %{^map_tile_id => %{program: updated_program} } } = InstanceProcess.inspect_state(instance_process)
+    { %{^map_tile_id => %{program: updated_program} }, {_, _} } = InstanceProcess.inspect_state(instance_process)
     refute program == updated_program
     assert_receive %Phoenix.Socket.Broadcast{
             topic: ^player_channel,
@@ -93,7 +93,7 @@ defmodule DungeonCrawl.InstanceProcessTest do
 
     # prunes the program if died during the run of the label
     InstanceProcess.send_event(instance_process, map_tile_id, "TERMINATE", player_location)
-    assert { %{} } = InstanceProcess.inspect_state(instance_process)
+    assert { %{}, {_, _} } = InstanceProcess.inspect_state(instance_process)
   end
 
   test "perform_actions", %{instance_process: instance_process, map_instance: map_instance} do

--- a/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
@@ -63,7 +63,7 @@ defmodule DungeonCrawl.InstanceRegistryTest do
 
     dungeon_map_tiles = [map_tile]
 
-    assert :ok = InstanceRegistry.create(instance_registry, map_tile.map_instance_id, dungeon_map_tiles)
+    assert map_tile.map_instance_id == InstanceRegistry.create(instance_registry, map_tile.map_instance_id, dungeon_map_tiles)
     assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, map_tile.map_instance_id)
 
     # the instance map is loaded
@@ -71,6 +71,13 @@ defmodule DungeonCrawl.InstanceRegistryTest do
     assert by_ids == %{map_tile.id => Map.put(map_tile, :parsed_state, %{})}
     assert by_coords ==  %{ {map_tile.row, map_tile.col} => %{map_tile.z_index => map_tile.id} }
     assert programs == %{}
+
+    # if no instance_id is given, it gets an available id and returns it
+    assert instance_id = InstanceRegistry.create(instance_registry, nil, dungeon_map_tiles)
+    refute instance_id == map_tile.map_instance_id
+    assert {:ok, instance_process2} = InstanceRegistry.lookup(instance_registry, instance_id)
+    assert { programs, {by_ids , by_coords} } = InstanceProcess.inspect_state(instance_process2)
+    assert by_ids == %{map_tile.id => Map.merge(map_tile, %{map_instance_id: instance_id, parsed_state: %{}})}
   end
 
   @tag capture_log: true

--- a/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
@@ -1,7 +1,7 @@
 defmodule DungeonCrawl.InstanceRegistryTest do
   use DungeonCrawl.DataCase
 
-  alias DungeonCrawl.DungeonProcesses.{InstanceRegistry,InstanceProcess}
+  alias DungeonCrawl.DungeonProcesses.{InstanceRegistry,InstanceProcess,Instances}
   alias DungeonCrawl.Scripting.Program
 
   setup do
@@ -39,7 +39,7 @@ defmodule DungeonCrawl.InstanceRegistryTest do
     assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, instance.id)
 
     # the instance map is loaded
-    assert {programs, {_, _} } = InstanceProcess.inspect_state(instance_process)
+    assert %Instances{program_contexts: programs} = InstanceProcess.get_state(instance_process)
     assert programs == %{map_tile.id => %{
                                            object: Map.put(map_tile, :parsed_state, %{blocking: true}),
                                            program: %Program{broadcasts: [],
@@ -67,7 +67,7 @@ defmodule DungeonCrawl.InstanceRegistryTest do
     assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, map_tile.map_instance_id)
 
     # the instance map is loaded
-    assert { programs, {by_ids , by_coords} } = InstanceProcess.inspect_state(instance_process)
+    assert %Instances{program_contexts: programs, map_by_ids: by_ids, map_by_coords: by_coords} = InstanceProcess.get_state(instance_process)
     assert by_ids == %{map_tile.id => Map.put(map_tile, :parsed_state, %{})}
     assert by_coords ==  %{ {map_tile.row, map_tile.col} => %{map_tile.z_index => map_tile.id} }
     assert programs == %{}
@@ -76,7 +76,7 @@ defmodule DungeonCrawl.InstanceRegistryTest do
     assert instance_id = InstanceRegistry.create(instance_registry, nil, dungeon_map_tiles)
     refute instance_id == map_tile.map_instance_id
     assert {:ok, instance_process2} = InstanceRegistry.lookup(instance_registry, instance_id)
-    assert { programs, {by_ids , by_coords} } = InstanceProcess.inspect_state(instance_process2)
+    assert %Instances{program_contexts: programs, map_by_ids: by_ids, map_by_coords: by_coords} = InstanceProcess.get_state(instance_process2)
     assert by_ids == %{map_tile.id => Map.merge(map_tile, %{map_instance_id: instance_id, parsed_state: %{}})}
   end
 

--- a/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
@@ -60,6 +60,15 @@ defmodule DungeonCrawl.InstanceRegistryTest do
     # the scheduler
   end
 
+  @tag capture_log: true
+  test "create safely handles a dungeon instance that does not exist in the DB", %{instance_registry: instance_registry} do
+    instance = insert_stubbed_dungeon_instance()
+    DungeonCrawl.DungeonInstances.delete_map!(instance)
+    log = ExUnit.CaptureLog.capture_log(fn -> InstanceRegistry.create(instance_registry, instance.id); :timer.sleep 1 end)
+    assert :error = InstanceRegistry.lookup(instance_registry, instance.id)
+    assert log =~ "Got a CREATE cast for #{instance.id} but its already been cleared"
+   end
+
   test "remove", %{instance_registry: instance_registry} do
     instance = insert_stubbed_dungeon_instance()
     InstanceRegistry.create(instance_registry, instance.id)

--- a/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
@@ -1,0 +1,81 @@
+defmodule DungeonCrawl.InstanceRegistryTest do
+  use DungeonCrawl.DataCase
+
+  alias DungeonCrawl.DungeonProcesses.{InstanceRegistry,InstanceProcess}
+  alias DungeonCrawl.Scripting.Program
+
+  setup do
+    instance_registry = start_supervised!(InstanceRegistry)
+    %{instance_registry: instance_registry}
+  end
+
+  test "lookup", %{instance_registry: instance_registry} do
+    instance = insert_stubbed_dungeon_instance()
+
+    assert :error = InstanceRegistry.lookup(instance_registry, instance.id)
+
+    InstanceRegistry.create(instance_registry, instance.id)
+    
+    assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, instance.id)
+  end
+
+  test "lookup_or_create", %{instance_registry: instance_registry} do
+    instance = insert_stubbed_dungeon_instance()
+
+    assert {:ok, instance_process} = InstanceRegistry.lookup_or_create(instance_registry, instance.id)
+    # Finds the already existing one
+    assert {:ok, instance_process} == InstanceRegistry.lookup_or_create(instance_registry, instance.id)
+  end
+
+  test "create", %{instance_registry: instance_registry} do
+    button_tile = insert_tile_template(%{state: "blocking: true", script: "#END\n:TOUCH\n*PimPom*"})
+    instance = insert_stubbed_dungeon_instance(%{},
+      [Map.merge(%{row: 1, col: 2, tile_template_id: button_tile.id, z_index: 0},
+                 Map.take(button_tile, [:character,:color,:background_color,:state,:script]))])
+
+    map_tile = Repo.get_by(DungeonCrawl.DungeonInstances.MapTile, %{map_instance_id: instance.id, row: 1, col: 2})
+
+    assert :ok = InstanceRegistry.create(instance_registry, instance.id)
+    assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, instance.id)
+
+    # the instance map is loaded
+    assert {programs} = InstanceProcess.inspect_state(instance_process)
+    assert programs == %{map_tile.id => %{
+                                           object: map_tile,
+                                           program: %Program{broadcasts: [],
+                                                             instructions: %{1 => [:halt, [""]],
+                                                                             2 => [:noop, "TOUCH"],
+                                                                             3 => [:text, ["*PimPom*"]]},
+                                                             labels: %{"TOUCH" => [[2, true]]},
+                                                             locked: false,
+                                                             pc: 1,
+                                                             responses: [],
+                                                             status: :alive,
+                                                             wait_cycles: 0
+                                                    },
+                                          event_sender: nil
+                                        }
+                       }
+    # the scheduler should be started too. Not sure a good way to test this via this spec. It will be apparent though if
+    # the scheduler
+  end
+
+  test "removes instances on exit", %{instance_registry: instance_registry} do
+    instance = insert_stubbed_dungeon_instance()
+    InstanceRegistry.create(instance_registry, instance.id)
+    assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, instance.id)
+
+    GenServer.stop(instance_process)
+    assert :error = InstanceRegistry.lookup(instance_registry, instance.id)
+  end
+
+  test "removes bucket on crash", %{instance_registry: instance_registry} do
+    instance = insert_stubbed_dungeon_instance()
+    InstanceRegistry.create(instance_registry, instance.id)
+    assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, instance.id)
+
+    # Stop the bucket with a non-normal reason
+    GenServer.stop(instance_process, :shutdown)
+    assert :error = InstanceRegistry.lookup(instance_registry, instance.id)
+  end
+end

--- a/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
@@ -60,6 +60,17 @@ defmodule DungeonCrawl.InstanceRegistryTest do
     # the scheduler
   end
 
+  test "remove", %{instance_registry: instance_registry} do
+    instance = insert_stubbed_dungeon_instance()
+    InstanceRegistry.create(instance_registry, instance.id)
+    assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, instance.id)
+
+    # seems to take a quick micro second for the cast to be done
+    InstanceRegistry.remove(instance_registry, instance.id)
+    :timer.sleep 1
+    assert :error = InstanceRegistry.lookup(instance_registry, instance.id)
+  end
+
   test "removes instances on exit", %{instance_registry: instance_registry} do
     instance = insert_stubbed_dungeon_instance()
     InstanceRegistry.create(instance_registry, instance.id)

--- a/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
@@ -39,9 +39,9 @@ defmodule DungeonCrawl.InstanceRegistryTest do
     assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, instance.id)
 
     # the instance map is loaded
-    assert {programs} = InstanceProcess.inspect_state(instance_process)
+    assert {programs, {_, _} } = InstanceProcess.inspect_state(instance_process)
     assert programs == %{map_tile.id => %{
-                                           object: map_tile,
+                                           object: Map.put(map_tile, :parsed_state, %{blocking: true}),
                                            program: %Program{broadcasts: [],
                                                              instructions: %{1 => [:halt, [""]],
                                                                              2 => [:noop, "TOUCH"],

--- a/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instance_registry_test.exs
@@ -69,7 +69,7 @@ defmodule DungeonCrawl.InstanceRegistryTest do
     assert :error = InstanceRegistry.lookup(instance_registry, instance.id)
   end
 
-  test "removes bucket on crash", %{instance_registry: instance_registry} do
+  test "removes instance on crash", %{instance_registry: instance_registry} do
     instance = insert_stubbed_dungeon_instance()
     InstanceRegistry.create(instance_registry, instance.id)
     assert {:ok, instance_process} = InstanceRegistry.lookup(instance_registry, instance.id)

--- a/test/dungeon_crawl/dungeon_processes/instances_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instances_test.exs
@@ -1,0 +1,35 @@
+defmodule DungeonCrawl.DungeonProcesses.InstancesTest do
+  use DungeonCrawl.DataCase
+
+  alias DungeonCrawl.DungeonProcesses.InstanceRegistry
+  alias DungeonCrawl.DungeonProcesses.Instances
+
+  setup do
+    instance_registry = start_supervised!(InstanceRegistry)
+    map_tile =       %{id: 999, map_instance_id: 12345, row: 1, col: 2, z_index: 0, character: "B", state: "", script: ""}
+    map_tile_south = %{id: 998, map_instance_id: 12345, row: 1, col: 3, z_index: 0, character: "S", state: "", script: ""}
+    dungeon_map_tiles = [map_tile, map_tile_south]
+
+    InstanceRegistry.create(instance_registry, map_tile.map_instance_id, dungeon_map_tiles)
+    %{instance_registry: instance_registry}
+  end
+
+  test "get_map_tile_by_id/1 gets the map tile for the id", %{instance_registry: instance_registry} do
+    assert %{id: 999} = Instances.get_map_tile_by_id(%{id: 999, map_instance_id: 12345}, instance_registry)
+  end
+
+  test "get_map_tile/1 gets the top map tile at the given coordinates", %{instance_registry: instance_registry} do
+    assert %{id: 999} = Instances.get_map_tile(%{row: 1, col: 2, map_instance_id: 12345}, nil, instance_registry)
+  end
+
+  test "get_map_tile/2 gets the top map tile in the given direction", %{instance_registry: instance_registry} do
+    assert %{id: 998} = Instances.get_map_tile(%{row: 1, col: 2, map_instance_id: 12345}, "east", instance_registry)
+  end
+
+  test "update_map_tile/2 updates the map tile", %{instance_registry: instance_registry} do
+    map_tile = Instances.get_map_tile(%{id: 999, row: 1, col: 2, map_instance_id: 12345}, nil, instance_registry)
+    new_attributes = %{id: 333, row: 2, col: 2, character: "M"}
+
+    assert Map.merge(map_tile, %{row: 2, col: 2, character: "M"}) == Instances.update_map_tile(map_tile, new_attributes, instance_registry)
+  end
+end

--- a/test/dungeon_crawl/dungeon_processes/instances_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instances_test.exs
@@ -1,35 +1,209 @@
 defmodule DungeonCrawl.DungeonProcesses.InstancesTest do
   use DungeonCrawl.DataCase
 
-  alias DungeonCrawl.DungeonProcesses.InstanceRegistry
+  import ExUnit.CaptureLog
+
   alias DungeonCrawl.DungeonProcesses.Instances
+  alias DungeonCrawl.Player.Location
+  alias DungeonCrawl.DungeonInstances.MapTile
 
   setup do
-    #instance_registry = start_supervised!(InstanceRegistry)
-    map_tile =       %{id: 999, row: 1, col: 2, z_index: 0, character: "B", state: "", script: ""}
-    map_tile_south = %{id: 998, row: 1, col: 3, z_index: 0, character: "S", state: "", script: ""}
-    dungeon_map_tiles = [map_tile, map_tile_south]
+    map_tile =        %MapTile{id: 999, row: 1, col: 2, z_index: 0, character: "B", state: "", script: "#END\n:TOUCH\nHey\n#END\n:TERMINATE\n#DIE"}
+    map_tile_south_1  = %MapTile{id: 997, row: 1, col: 3, z_index: 1, character: "S", state: "", script: ""}
+    map_tile_south_2  = %MapTile{id: 998, row: 1, col: 3, z_index: 0, character: "X", state: "", script: ""}
 
-    instance_id = InstanceRegistry.create(DungeonInstanceRegistry, nil, dungeon_map_tiles)
-    %{instance_id: instance_id}
+    {_, state} = Instances.create_map_tile(%Instances{}, map_tile)
+    {_, state} = Instances.create_map_tile(state, map_tile_south_1)
+    {_, state} = Instances.create_map_tile(state, map_tile_south_2)
+
+    %{state: state}
   end
 
-  test "get_map_tile_by_id/1 gets the map tile for the id", %{instance_id: instance_id} do
-    assert %{id: 999} = Instances.get_map_tile_by_id(%{id: 999, map_instance_id: instance_id})
+  test "the state looks right", %{state: state} do
+    assert %Instances{
+      program_contexts: %{999 => %{
+                  event_sender: nil,
+                  object: %{ id: 999, character: "B", # ...
+                  },
+                  program: %DungeonCrawl.Scripting.Program{
+                    broadcasts: [],
+                    instructions: %{
+                      1 => [:halt, [""]],
+                      2 => [:noop, "TOUCH"],
+                      3 => [:text, ["Hey"]],
+                      4 => [:halt, [""]],
+                      5 => [:noop, "TERMINATE"],
+                      6 => [:die, [""]]
+                    },
+                    labels: %{
+                      "TERMINATE" => [[5, true]],
+                      "TOUCH" => [[2, true]]
+                    },
+                    locked: false,
+                    pc: 1,
+                    responses: [],
+                    status: :alive,
+                    wait_cycles: 0
+                  }
+                }
+             },
+      map_by_ids: %{999 => %{id: 999}, # More here, but this is good enough for a smoke test
+                    997 => %{id: 997},
+                    998 => %{id: 998}},
+      map_by_coords: %{ {1, 2} => %{0 => 999},
+                        {1, 3} => %{1 => 997, 0 => 998} }
+    } = state
   end
 
-  test "get_map_tile/1 gets the top map tile at the given coordinates", %{instance_id: instance_id} do
-    assert %{id: 999} = Instances.get_map_tile(%{row: 1, col: 2, map_instance_id: instance_id})
+  test "get_map_tile/1 gets the top map tile at the given coordinates", %{state: state} do
+    assert %{id: 999} = Instances.get_map_tile(state, %{row: 1, col: 2})
   end
 
-  test "get_map_tile/2 gets the top map tile in the given direction", %{instance_id: instance_id} do
-    assert %{id: 998} = Instances.get_map_tile(%{row: 1, col: 2, map_instance_id: instance_id}, "east")
+  test "get_map_tile/2 gets the top map tile in the given direction", %{state: state} do
+    assert %{id: 997} = Instances.get_map_tile(state, %{row: 1, col: 2}, "east")
   end
 
-  test "update_map_tile/2 updates the map tile", %{instance_id: instance_id} do
-    map_tile = Instances.get_map_tile(%{id: 999, row: 1, col: 2, map_instance_id: instance_id}, nil)
+  test "get_map_tiles/2 gets the map tiles in the given direction", %{state: state} do
+    assert [map_tile_1, map_tile_2] = Instances.get_map_tiles(state, %{row: 1, col: 2}, "east")
+    assert %{id: 997} = map_tile_1
+    assert %{id: 998} = map_tile_2
+  end
+
+  test "get_map_tiles/2 gets empty array in the given direction", %{state: state} do
+    assert [] == Instances.get_map_tiles(state, %{row: 1, col: 2}, "north")
+  end
+
+  test "get_map_tile_by_id/1 gets the map tile for the id", %{state: state} do
+    assert %{id: 999} = Instances.get_map_tile_by_id(state, %{id: 999})
+  end
+
+  test "responds_to_event?/3", %{state: state} do
+    assert Instances.responds_to_event?(state, %{id: 999}, "TOUCH")
+    refute Instances.responds_to_event?(state, %{id: 999}, "SNIFF")
+    refute Instances.responds_to_event?(state, %{id: 222}, "ANYTHING")
+  end
+
+  test "send_event", %{state: state} do
+    player_location = %Location{id: 555}
+
+    player_channel = "players:#{player_location.id}"
+    DungeonCrawlWeb.Endpoint.subscribe(player_channel)
+
+    %Instances{ program_contexts: %{999 => %{program: program} },
+                map_by_ids: _,
+                map_by_coords: _ } = state
+
+    # noop if it tile doesnt have a program
+    updated_state = Instances.send_event(state, %{id: 111}, "TOUCH", player_location)
+    %Instances{ program_contexts: %{999 => %{program: ^program} },
+                map_by_ids: _,
+                map_by_coords: _ } = updated_state
+
+    # it does something
+    updated_state_2 = Instances.send_event(updated_state, %{id: 999}, "TOUCH", player_location)
+    %Instances{ program_contexts: %{999 => %{program: updated_program} },
+                map_by_ids: _,
+                map_by_coords: _ } = updated_state_2
+    refute program == updated_program
+    assert_receive %Phoenix.Socket.Broadcast{
+            topic: ^player_channel,
+            event: "message",
+            payload: %{message: "Hey"}}
+
+    # prunes the program if died during the run of the label
+    updated_state_3 = Instances.send_event(updated_state_2, %{id: 999}, "TERMINATE", player_location)
+    %Instances{ program_contexts: %{} ,
+                map_by_ids: _,
+                map_by_coords: _ } = updated_state_3
+  end
+
+  test "create_map_tile/1 creates a map tile" do
+    new_map_tile = %{id: 1, row: 4, col: 4, z_index: 0, character: "M", state: "", script: ""}
+
+    {new_map_tile, state} = Instances.create_map_tile(%Instances{}, new_map_tile)
+
+    assert %{id: 1, character: "M"} = new_map_tile
+    assert %Instances{
+      program_contexts: %{},
+      map_by_ids: %{1 =>  Map.put(new_map_tile, :parsed_state, %{})},
+      map_by_coords: %{ {4, 4} => %{0 => 1} }
+    } == state
+
+    # returns the existing tile if it already exists by id
+    assert {^new_map_tile, ^state} = Instances.create_map_tile(state, Map.put(new_map_tile, :character, "O"))
+    assert %{id: 1, character: "M"} = new_map_tile
+
+    # Does not load a corrupt script (edge case - corrupt script shouldnt even get into the DB, and logs a warning
+    map_tile_bad_script = %MapTile{row: 1, col: 4, id: 123, script: "#NOT_A_REAL_COMMAND"}
+    assert capture_log(fn ->
+             assert {map_tile, updated_state} = Instances.create_map_tile(state, map_tile_bad_script)
+             assert %Instances{ program_contexts: %{},
+                                map_by_ids: %{1 => Map.put(new_map_tile, :parsed_state, %{}),
+                                              123 => Map.put(map_tile_bad_script, :parsed_state, %{})},
+                                map_by_coords: %{{1, 4} => %{0 => 123}, {4, 4} => %{0 => 1}} } == updated_state
+           end) =~ ~r/Possible corrupt script for map tile instance:/
+  end
+
+  test "update_map_tile/2 updates the map tile", %{state: state} do
+    map_tile = Instances.get_map_tile(state, %{id: 999, row: 1, col: 2})
     new_attributes = %{id: 333, row: 2, col: 2, character: "M"}
 
-    assert Map.merge(map_tile, %{row: 2, col: 2, character: "M"}) == Instances.update_map_tile(map_tile, new_attributes)
+    assert {updated_tile, updated_state} = Instances.update_map_tile(state, map_tile, new_attributes)
+    assert Map.merge(map_tile, %{row: 2, col: 2, character: "M"}) == updated_tile
+    assert %{dirty_ids: %{999 => changeset}} = updated_state
+    assert changeset.changes == MapTile.changeset(map_tile,%{character: "M", row: 2}).changes
+  end
+
+  test "update_tile/3", %{state: state} do
+    map_tile_id = 999
+    assert {updated_tile, state} = Instances.update_map_tile(state, %{id: map_tile_id}, %{id: 11111, character: "X", row: 1, col: 1})
+    assert %{id: ^map_tile_id, character: "X", row: 1, col: 1} = state.map_by_ids[map_tile_id]
+    assert %{dirty_ids: %{999 => changeset}} = state
+    assert changeset.changes == MapTile.changeset(%MapTile{},%{character: "X", col: 1}).changes
+
+    # Move to an empty space
+    assert {updated_tile, state} = Instances.update_map_tile(state, %{id: map_tile_id}, %{row: 2, col: 3})
+    assert %{id: ^map_tile_id, character: "X", row: 2, col: 3} = state.map_by_ids[map_tile_id]
+    assert %{dirty_ids: %{999 => changeset}} = state
+    assert changeset.changes == MapTile.changeset(%MapTile{},%{character: "X", row: 2, col: 3}).changes
+
+    # Move ontop of another tile
+    another_map_tile = %MapTile{id: -3, character: "O", row: 5, col: 6, z_index: 0}
+    {_another_map_tile, state} = Instances.create_map_tile(state, another_map_tile)
+
+    # Won't move to the same z_index
+    assert {updated_tile, state} = Instances.update_map_tile(state, %{id: map_tile_id}, %{row: 5, col: 6})
+    assert %MapTile{id: ^map_tile_id, character: "X", row: 2, col: 3, z_index: 0} = state.map_by_ids[map_tile_id]
+    assert {updated_tile, state} = Instances.update_map_tile(state, %{id: map_tile_id}, %{row: 5, col: 6, z_index: 1})
+    assert %MapTile{id: ^map_tile_id, character: "X", row: 5, col: 6, z_index: 1} = state.map_by_ids[map_tile_id]
+    assert %MapTile{id: -3, character: "O", row: 5, col: 6, z_index: 0} = state.map_by_ids[-3]
+
+    # Move the new tile
+    assert {updated_tile, state} = Instances.update_map_tile(state, %{id: -3}, %{character: "M"})
+    assert %{dirty_ids: %{999 => changeset_999, -3 => changeset_neg_3}} = state
+    assert changeset_999.changes == MapTile.changeset(%MapTile{},%{character: "X", row: 5, col: 6, z_index: 1}).changes
+    assert changeset_neg_3.changes == MapTile.changeset(%MapTile{},%{character: "M"}).changes
+  end
+
+  test "delete_map_tile/1 deletes the map tile", %{state: state} do
+    map_tile_id = 999
+    map_tile = state.map_by_ids[map_tile_id]
+
+    %Instances{ program_contexts: programs,
+                map_by_ids: by_id,
+                map_by_coords: by_coord } = state
+    assert programs[map_tile.id]
+    assert by_id[map_tile.id]
+    assert %{ {1, 2} => %{ 0 => ^map_tile_id} } = by_coord
+
+    assert {deleted_tile, state} = Instances.delete_map_tile(state, map_tile)
+    refute state.map_by_ids[map_tile_id]
+    %Instances{ program_contexts: programs,
+                map_by_ids: by_id,
+                map_by_coords: by_coord,
+                dirty_ids: %{^map_tile_id => :deleted} } = state
+    refute programs[map_tile_id]
+    refute by_id[map_tile_id]
+    assert %{ {1, 2} => %{} } = by_coord
   end
 end

--- a/test/dungeon_crawl/dungeon_processes/instances_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instances_test.exs
@@ -5,31 +5,31 @@ defmodule DungeonCrawl.DungeonProcesses.InstancesTest do
   alias DungeonCrawl.DungeonProcesses.Instances
 
   setup do
-    instance_registry = start_supervised!(InstanceRegistry)
-    map_tile =       %{id: 999, map_instance_id: 12345, row: 1, col: 2, z_index: 0, character: "B", state: "", script: ""}
-    map_tile_south = %{id: 998, map_instance_id: 12345, row: 1, col: 3, z_index: 0, character: "S", state: "", script: ""}
+    #instance_registry = start_supervised!(InstanceRegistry)
+    map_tile =       %{id: 999, row: 1, col: 2, z_index: 0, character: "B", state: "", script: ""}
+    map_tile_south = %{id: 998, row: 1, col: 3, z_index: 0, character: "S", state: "", script: ""}
     dungeon_map_tiles = [map_tile, map_tile_south]
 
-    InstanceRegistry.create(instance_registry, map_tile.map_instance_id, dungeon_map_tiles)
-    %{instance_registry: instance_registry}
+    instance_id = InstanceRegistry.create(DungeonInstanceRegistry, nil, dungeon_map_tiles)
+    %{instance_id: instance_id}
   end
 
-  test "get_map_tile_by_id/1 gets the map tile for the id", %{instance_registry: instance_registry} do
-    assert %{id: 999} = Instances.get_map_tile_by_id(%{id: 999, map_instance_id: 12345}, instance_registry)
+  test "get_map_tile_by_id/1 gets the map tile for the id", %{instance_id: instance_id} do
+    assert %{id: 999} = Instances.get_map_tile_by_id(%{id: 999, map_instance_id: instance_id})
   end
 
-  test "get_map_tile/1 gets the top map tile at the given coordinates", %{instance_registry: instance_registry} do
-    assert %{id: 999} = Instances.get_map_tile(%{row: 1, col: 2, map_instance_id: 12345}, nil, instance_registry)
+  test "get_map_tile/1 gets the top map tile at the given coordinates", %{instance_id: instance_id} do
+    assert %{id: 999} = Instances.get_map_tile(%{row: 1, col: 2, map_instance_id: instance_id})
   end
 
-  test "get_map_tile/2 gets the top map tile in the given direction", %{instance_registry: instance_registry} do
-    assert %{id: 998} = Instances.get_map_tile(%{row: 1, col: 2, map_instance_id: 12345}, "east", instance_registry)
+  test "get_map_tile/2 gets the top map tile in the given direction", %{instance_id: instance_id} do
+    assert %{id: 998} = Instances.get_map_tile(%{row: 1, col: 2, map_instance_id: instance_id}, "east")
   end
 
-  test "update_map_tile/2 updates the map tile", %{instance_registry: instance_registry} do
-    map_tile = Instances.get_map_tile(%{id: 999, row: 1, col: 2, map_instance_id: 12345}, nil, instance_registry)
+  test "update_map_tile/2 updates the map tile", %{instance_id: instance_id} do
+    map_tile = Instances.get_map_tile(%{id: 999, row: 1, col: 2, map_instance_id: instance_id}, nil)
     new_attributes = %{id: 333, row: 2, col: 2, character: "M"}
 
-    assert Map.merge(map_tile, %{row: 2, col: 2, character: "M"}) == Instances.update_map_tile(map_tile, new_attributes, instance_registry)
+    assert Map.merge(map_tile, %{row: 2, col: 2, character: "M"}) == Instances.update_map_tile(map_tile, new_attributes)
   end
 end

--- a/test/dungeon_crawl/scripting/parser_test.exs
+++ b/test/dungeon_crawl/scripting/parser_test.exs
@@ -43,7 +43,7 @@ defmodule DungeonCrawl.Scripting.ParserTest do
       assert {:ok, program = %Program{}} = Parser.parse(script)
       assert program == %Program{instructions: %{1 => [:halt, [""]],
                                                  2 => [:noop, "TOUCH"],
-                                                 3 => [:if, [["", :check_state, :open, "==", true], "ALREADY_OPEN"]],
+                                                 3 => [:jump_if, [["", :check_state, :open, "==", true], "ALREADY_OPEN"]],
                                                  4 => [:become, [%{character: "'", color: "white"}]],
                                                  5 => [:text, ["The door creaks open"]],
                                                  6 => [:halt, [""]],

--- a/test/dungeon_crawl/scripting/parser_test.exs
+++ b/test/dungeon_crawl/scripting/parser_test.exs
@@ -37,6 +37,8 @@ defmodule DungeonCrawl.Scripting.ParserTest do
                Can't open it anymore.
                @counter += 1
                #BECOME TTID:#{tile_template.id}
+               #MOVE south, true
+               #MOVE east
                """
       assert {:ok, program = %Program{}} = Parser.parse(script)
       assert program == %Program{instructions: %{1 => [:halt, [""]],
@@ -49,7 +51,9 @@ defmodule DungeonCrawl.Scripting.ParserTest do
                                                  8 => [:text, ["Door is already open."]],
                                                  9 => [:text, ["Can't open it anymore."]],
                                                  10 => [:change_state, [:counter, "+=", 1]],
-                                                 11 => [:become, [{:ttid, tile_template.id}]]
+                                                 11 => [:become, [{:ttid, tile_template.id}]],
+                                                 12 => [:move, ["south", true]],
+                                                 13 => [:move, ["east"]]
                                                  },
                                  status: :alive,
                                  pc: 1,

--- a/test/dungeon_crawl/scripting/program_validator_test.exs
+++ b/test/dungeon_crawl/scripting/program_validator_test.exs
@@ -14,6 +14,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidatorTest do
     #END
     :MORE
     thing is true
+    #MOVE south, true
     """
   end
 
@@ -27,6 +28,10 @@ defmodule DungeonCrawl.Scripting.ProgramValidatorTest do
     #BECOME TTID:#{ttid}
     #BECOME TTID:#{ttid2}
     #BECOME character:  , color:red
+    #MOVE banana, true
+    #MOVE north, false
+    #MOVE south
+    #MOVE hotpockets
     """
   end
 
@@ -51,12 +56,16 @@ defmodule DungeonCrawl.Scripting.ProgramValidatorTest do
               ["Line 3: BECOME command has errors: `character - should be at most 1 character(s)`",
                "Line 5: IF command references nonexistant label `NOLABEL`",
                "Line 6: BECOME command references a TTID that you can't use `#{tt.id}`",
-               "Line 8: BECOME command params not being detected as kwargs `[\"character:\", \"color:red\"]`"],
+               "Line 8: BECOME command params not being detected as kwargs `[\"character:\", \"color:red\"]`",
+               "Line 9: MOVE command references invalid direction `banana`",
+               "Line 12: MOVE command references invalid direction `hotpockets`"],
               program} == ProgramValidator.validate(program, user)
       assert {:error,
               ["Line 3: BECOME command has errors: `character - should be at most 1 character(s)`",
                "Line 5: IF command references nonexistant label `NOLABEL`",
-               "Line 8: BECOME command params not being detected as kwargs `[\"character:\", \"color:red\"]`"],
+               "Line 8: BECOME command params not being detected as kwargs `[\"character:\", \"color:red\"]`",
+               "Line 9: MOVE command references invalid direction `banana`",
+               "Line 12: MOVE command references invalid direction `hotpockets`"],
               program} == ProgramValidator.validate(program, admin)
     end
   end

--- a/test/dungeon_crawl/scripting/runner_test.exs
+++ b/test/dungeon_crawl/scripting/runner_test.exs
@@ -36,19 +36,6 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       assert run_program.responses == ["After label"]
     end
 
-    test "when given a nonexistent label returns the program with a helpful message in the responses" do
-      script = """
-               B4 label
-               :HERE
-               After label
-               """
-      {:ok, program} = Parser.parse(script)
-      stubbed_object = %{state: ""}
-
-      %{object: _, program: run_program} = Runner.run(%{program: program, object: stubbed_object, label: "NOT_A_REAL_LABEL"})
-      assert run_program.responses == ["Label not in script: NOT_A_REAL_LABEL"]
-    end
-
     test "when program is idle it runs nothing and just returns the program and object" do
       program = %Program{status: :idle, pc: 2}
       stubbed_object = %{state: ""}

--- a/test/dungeon_crawl/scripting/runner_test.exs
+++ b/test/dungeon_crawl/scripting/runner_test.exs
@@ -32,8 +32,16 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       stubbed_object = %{state: ""}
 
       %{object: _, program: run_program} = Runner.run(%{program: %{program | status: :idle}, object: stubbed_object, label: "HERE"})
-#      %{object: _, program: run_program} = Runner.run(%{program: run_program, object: stubbed_object})
       assert run_program.responses == ["After label"]
+    end
+
+    test "when given a label but no label matches" do
+      script = "No label"
+      {:ok, program} = Parser.parse(script)
+      stubbed_object = %{state: ""}
+
+      assert %{object: stubbed_object, program: %{program | status: :idle}} == 
+             Runner.run(%{program: %{program | status: :idle}, object: stubbed_object, label: "TOUCH"})
     end
 
     test "when program is idle it runs nothing and just returns the program and object" do

--- a/test/dungeon_crawl/scripting/runner_test.exs
+++ b/test/dungeon_crawl/scripting/runner_test.exs
@@ -15,6 +15,7 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       stubbed_object = %{state: ""}
 
       %{object: _, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
+      %{object: _, program: run_program} = Runner.run(%{program: run_program, object: stubbed_object})
       assert run_program.responses == ["Line Two", "Line One"]
 
       %{object: _, program: run_program} = Runner.run(%{program: %{program | pc: 2}, object: stubbed_object})
@@ -31,6 +32,7 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       stubbed_object = %{state: ""}
 
       %{object: _, program: run_program} = Runner.run(%{program: %{program | status: :idle}, object: stubbed_object, label: "HERE"})
+      %{object: _, program: run_program} = Runner.run(%{program: run_program, object: stubbed_object})
       assert run_program.responses == ["After label"]
     end
 
@@ -61,6 +63,22 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       %{object: object, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
       assert program == run_program
       assert object  == stubbed_object
+    end
+
+    test "when program is wait the wait_cycles are decremented" do
+      program = %Program{status: :wait, pc: 2, wait_cycles: 3}
+      stubbed_object = %{state: ""}
+      %{object: _object, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
+      assert run_program.wait_cycles == 2
+      assert run_program.status == :wait
+    end
+
+    test "when program is wait and wait_cycles become zero, program becomes alive" do
+      program = %Program{status: :wait, pc: 2, wait_cycles: 1}
+      stubbed_object = %{state: ""}
+      %{object: _object, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
+      assert run_program.wait_cycles == 0
+      assert run_program.status == :alive
     end
   end
 end

--- a/test/dungeon_crawl/scripting/runner_test.exs
+++ b/test/dungeon_crawl/scripting/runner_test.exs
@@ -15,7 +15,7 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       stubbed_object = %{state: ""}
 
       %{object: _, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
-      %{object: _, program: run_program} = Runner.run(%{program: run_program, object: stubbed_object})
+#      %{object: _, program: run_program} = Runner.run(%{program: run_program, object: stubbed_object})
       assert run_program.responses == ["Line Two", "Line One"]
 
       %{object: _, program: run_program} = Runner.run(%{program: %{program | pc: 2}, object: stubbed_object})
@@ -32,7 +32,7 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       stubbed_object = %{state: ""}
 
       %{object: _, program: run_program} = Runner.run(%{program: %{program | status: :idle}, object: stubbed_object, label: "HERE"})
-      %{object: _, program: run_program} = Runner.run(%{program: run_program, object: stubbed_object})
+#      %{object: _, program: run_program} = Runner.run(%{program: run_program, object: stubbed_object})
       assert run_program.responses == ["After label"]
     end
 

--- a/test/dungeon_crawl/scripting/runner_test.exs
+++ b/test/dungeon_crawl/scripting/runner_test.exs
@@ -14,11 +14,10 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       {:ok, program} = Parser.parse(script)
       stubbed_object = %{state: ""}
 
-      %{object: _, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
-#      %{object: _, program: run_program} = Runner.run(%{program: run_program, object: stubbed_object})
+      %Runner{program: run_program} = Runner.run(%Runner{program: program, object: stubbed_object})
       assert run_program.responses == ["Line Two", "Line One"]
 
-      %{object: _, program: run_program} = Runner.run(%{program: %{program | pc: 2}, object: stubbed_object})
+      %Runner{program: run_program} = Runner.run(%Runner{program: %{program | pc: 2}, object: stubbed_object})
       assert run_program.responses == ["Line Two"]
     end
 
@@ -31,7 +30,7 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       {:ok, program} = Parser.parse(script)
       stubbed_object = %{state: ""}
 
-      %{object: _, program: run_program} = Runner.run(%{program: %{program | status: :idle}, object: stubbed_object, label: "HERE"})
+      %Runner{program: run_program} = Runner.run(%Runner{program: %{program | status: :idle}, object: stubbed_object}, "HERE")
       assert run_program.responses == ["After label"]
     end
 
@@ -40,14 +39,14 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       {:ok, program} = Parser.parse(script)
       stubbed_object = %{state: ""}
 
-      assert %{object: stubbed_object, program: %{program | status: :idle}} == 
-             Runner.run(%{program: %{program | status: :idle}, object: stubbed_object, label: "TOUCH"})
+      assert %Runner{object: stubbed_object, program: %{program | status: :idle}} == 
+             Runner.run(%Runner{program: %{program | status: :idle}, object: stubbed_object}, "TOUCH")
     end
 
     test "when program is idle it runs nothing and just returns the program and object" do
       program = %Program{status: :idle, pc: 2}
       stubbed_object = %{state: ""}
-      %{object: object, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
+      %Runner{object: object, program: run_program} = Runner.run(%Runner{program: program, object: stubbed_object})
       assert program == run_program
       assert object  == stubbed_object
     end
@@ -55,7 +54,7 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
     test "when program is dead runs nothing and just returns the program and object" do
       program = %Program{status: :dead, pc: 2}
       stubbed_object = %{state: ""}
-      %{object: object, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
+      %Runner{object: object, program: run_program} = Runner.run(%Runner{program: program, object: stubbed_object})
       assert program == run_program
       assert object  == stubbed_object
     end
@@ -63,7 +62,7 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
     test "when program is wait the wait_cycles are decremented" do
       program = %Program{status: :wait, pc: 2, wait_cycles: 3}
       stubbed_object = %{state: ""}
-      %{object: _object, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
+      %Runner{object: _object, program: run_program} = Runner.run(%Runner{program: program, object: stubbed_object})
       assert run_program.wait_cycles == 2
       assert run_program.status == :wait
     end
@@ -71,7 +70,7 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
     test "when program is wait and wait_cycles become zero, program becomes alive" do
       program = %Program{status: :wait, pc: 2, wait_cycles: 1}
       stubbed_object = %{state: ""}
-      %{object: _object, program: run_program} = Runner.run(%{program: program, object: stubbed_object})
+      %Runner{object: _object, program: run_program} = Runner.run(%Runner{program: program, object: stubbed_object})
       assert run_program.wait_cycles == 0
       assert run_program.status == :alive
     end

--- a/test/dungeon_crawl_web/channels/dungeon_channel_test.exs
+++ b/test/dungeon_crawl_web/channels/dungeon_channel_test.exs
@@ -69,6 +69,14 @@ defmodule DungeonCrawl.DungeonChannelTest do
     assert_broadcast "tile_changes", %{tiles: [%{col: 1, row: 2, rendering: "<div>@</div>"}, %{col: 1, row: 3, rendering: "<div>.</div>"}]}
   end
 
+  @tag up_tile: "."
+  test "move broadcasts a tile_update if its a valid move when starting location only had the tile that moved", %{socket: socket} do
+    Repo.get_by(Dungeon.MapTile, %{row: @player_row, col: @player_col, z_index: 0})
+    |> Repo.delete!
+    push socket, "move", %{"direction" => "up"}
+    assert_broadcast "tile_changes", %{tiles: [%{col: 1, row: 2, rendering: "<div>@</div>"}, %{col: 1, row: 3, rendering: "<div></div>"}]}
+  end
+
   @tag up_tile: "#"
   test "move broadcasts nothing if its not a valid move", %{socket: socket} do
     push socket, "move", %{"direction" => "up"}
@@ -77,6 +85,15 @@ defmodule DungeonCrawl.DungeonChannelTest do
 
   @tag up_tile: "."
   test "step does not reply if nothing happens", %{socket: socket} do
+    ref = push socket, "step", %{"direction" => "up"}
+    refute_reply ref, _, _
+    refute_broadcast _any_event, _any_payload
+  end
+
+  @tag up_tile: "."
+  test "step does not reply if there is no tile", %{socket: socket} do
+    Repo.get_by(Dungeon.MapTile, %{row: @player_row-1, col: @player_col})
+    |> Repo.delete!
     ref = push socket, "step", %{"direction" => "up"}
     refute_reply ref, _, _
     refute_broadcast _any_event, _any_payload

--- a/test/dungeon_crawl_web/channels/dungeon_channel_test.exs
+++ b/test/dungeon_crawl_web/channels/dungeon_channel_test.exs
@@ -2,7 +2,9 @@ defmodule DungeonCrawl.DungeonChannelTest do
   use DungeonCrawlWeb.ChannelCase
 
   alias DungeonCrawlWeb.DungeonChannel
-  alias DungeonCrawl.DungeonInstances, as: Dungeon
+  alias DungeonCrawl.DungeonInstances
+  alias DungeonCrawl.DungeonProcesses.InstanceProcess
+  alias DungeonCrawl.DungeonProcesses.InstanceRegistry
   alias DungeonCrawl.TileTemplates
   alias DungeonCrawl.TileTemplates.TileSeeder
 
@@ -71,8 +73,9 @@ defmodule DungeonCrawl.DungeonChannelTest do
 
   @tag up_tile: "."
   test "move broadcasts a tile_update if its a valid move when starting location only had the tile that moved", %{socket: socket} do
-    Repo.get_by(Dungeon.MapTile, %{row: @player_row, col: @player_col, z_index: 0})
-    |> Repo.delete!
+    map_tile = Repo.get_by(DungeonInstances.MapTile, %{row: @player_row, col: @player_col, z_index: 0})
+    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, map_tile.map_instance_id)
+    InstanceProcess.delete_tile(instance, map_tile.id)
     push socket, "move", %{"direction" => "up"}
     assert_broadcast "tile_changes", %{tiles: [%{col: 1, row: 2, rendering: "<div>@</div>"}, %{col: 1, row: 3, rendering: "<div></div>"}]}
   end
@@ -92,7 +95,7 @@ defmodule DungeonCrawl.DungeonChannelTest do
 
   @tag up_tile: "."
   test "step does not reply if there is no tile", %{socket: socket} do
-    Repo.get_by(Dungeon.MapTile, %{row: @player_row-1, col: @player_col})
+    Repo.get_by(DungeonInstances.MapTile, %{row: @player_row-1, col: @player_col})
     |> Repo.delete!
     ref = push socket, "step", %{"direction" => "up"}
     refute_reply ref, _, _
@@ -119,35 +122,41 @@ defmodule DungeonCrawl.DungeonChannelTest do
   # TODO: refactor the underlying model/channel methods into more testable concerns
   @tag up_tile: "+"
   test "use_door with a valid actions", %{socket: socket, player_location: player_location, basic_tiles: basic_tiles} do
+    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, player_location.map_tile.map_instance_id)
+    north_tile = _player_location_north(player_location)
+
     push socket, "use_door", %{"direction" => "up", "action" => "OPEN"}
 
     assert_broadcast "tile_changes", %{tiles: [%{row: _, col: _, rendering: "<div>'</div>"}]}
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).tile_template_id == basic_tiles["'"].id
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).character == basic_tiles["'"].character
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).script == basic_tiles["'"].script
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).state == basic_tiles["'"].state
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).tile_template_id == basic_tiles["'"].id
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).character == basic_tiles["'"].character
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).script == basic_tiles["'"].script
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).state == basic_tiles["'"].state
 
     push socket, "use_door", %{"direction" => "up", "action" => "CLOSE"}
 
     assert_broadcast "tile_changes", %{tiles: [%{row: _, col: _, rendering: "<div>+</div>"}]}
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).tile_template_id == basic_tiles["+"].id
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).character == basic_tiles["+"].character
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).script == basic_tiles["+"].script
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).state == basic_tiles["+"].state
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).tile_template_id == basic_tiles["+"].id
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).character == basic_tiles["+"].character
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).script == basic_tiles["+"].script
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).state == basic_tiles["+"].state
   end
 
   @tag up_tile: "."
   test "use_door with an invalid actions", %{socket: socket, player_location: player_location, basic_tiles: basic_tiles} do
     player_channel = "players:#{player_location.id}"
     DungeonCrawlWeb.Endpoint.subscribe(player_channel)
+    north_tile = _player_location_north(player_location)
     push socket, "use_door", %{"direction" => "up", "action" => "OPEN"}
+
+    {:ok, instance} = InstanceRegistry.lookup_or_create(DungeonInstanceRegistry, player_location.map_tile.map_instance_id)
 
     assert_receive %Phoenix.Socket.Broadcast{
         topic: ^player_channel,
         event: "message",
         payload: %{message: "Cannot open that"}}
     refute_broadcast "tile_changes", _
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).tile_template_id == basic_tiles["."].id
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).tile_template_id == basic_tiles["."].id
 
     push socket, "use_door", %{"direction" => "up", "action" => "CLOSE"}
 
@@ -157,6 +166,6 @@ defmodule DungeonCrawl.DungeonChannelTest do
         payload: %{message: "Cannot close that"}}
 
     refute_broadcast "tile_changes", _
-    assert Dungeon.get_map_tile(_player_location_north(player_location)).tile_template_id == basic_tiles["."].id
+    assert InstanceProcess.get_tile(instance, north_tile.row, north_tile.col).tile_template_id == basic_tiles["."].id
   end
 end

--- a/test/dungeon_crawl_web/channels/player_channel_test.exs
+++ b/test/dungeon_crawl_web/channels/player_channel_test.exs
@@ -1,0 +1,18 @@
+defmodule DungeonCrawl.PlayerChannelTest do
+  use DungeonCrawlWeb.ChannelCase
+
+  alias DungeonCrawlWeb.PlayerChannel
+
+  setup do
+    {:ok, _, socket} =
+      socket(DungeonCrawlWeb.UserSocket, "user_id_hash", %{user_id_hash: "junkhashreal"})
+      |> subscribe_and_join(PlayerChannel, "players:12345")
+
+    {:ok, socket: socket}
+  end
+
+  test "ping replies with status ok", %{socket: socket} do
+    ref = push socket, "ping", %{"hello" => "there"}
+    assert_reply ref, :ok, %{"hello" => "there"}
+  end
+end

--- a/test/dungeon_crawl_web/views/shared_view_test.exs
+++ b/test/dungeon_crawl_web/views/shared_view_test.exs
@@ -44,7 +44,7 @@ defmodule DungeonCrawlWeb.SharedViewTest do
     assert style_d == "<div style='color: #FFF;background-color: #000'>D</div>"
   end
 
-  test "dungeon_as_table/1 returns table rows of the dungeon" do
+  test "dungeon_as_table/3 returns table rows of the dungeon" do
     tile_a = insert_tile_template(%{character: "A"})
     tile_b = insert_tile_template(%{character: "B", color: "#FFF"})
     map = insert_stubbed_dungeon(%{},
@@ -52,14 +52,14 @@ defmodule DungeonCrawlWeb.SharedViewTest do
              Map.merge(%{tile_template_id: tile_a.id, row: 1, col: 2, z_index: 0}, Map.take(tile_a, [:character, :color, :background_color, :state, :script])),
              Map.merge(%{tile_template_id: tile_b.id, row: 1, col: 3, z_index: 0}, Map.take(tile_b, [:character, :color, :background_color, :state, :script]))])
 
-    rows = dungeon_as_table(Repo.preload(map, :dungeon_map_tiles))
+    rows = dungeon_as_table(Repo.preload(map, :dungeon_map_tiles), map.width, map.height)
 
     assert rows =~ ~r{<td id='1_1'><div>A</div></td>}
     assert rows =~ ~r{<td id='1_2'><div>A</div></td>}
     assert rows =~ ~r{<td id='1_3'><div style='color: #FFF'>B</div></td>}
   end
 
-  test "dungeon_as_table/2 returns table rows of the dungeon including the data attributes" do
+  test "dungeon_as_table/4 returns table rows of the dungeon including the data attributes" do
     tile_a = insert_tile_template(%{character: "A"})
     tile_b = insert_tile_template(%{character: "B", color: "#FFF"})
     map = insert_stubbed_dungeon(%{},
@@ -67,7 +67,7 @@ defmodule DungeonCrawlWeb.SharedViewTest do
              Map.merge(%{tile_template_id: tile_a.id, row: 1, col: 2, z_index: 0}, Map.take(tile_a, [:character, :color, :background_color, :state, :script])),
              Map.merge(%{tile_template_id: tile_b.id, row: 1, col: 3, z_index: 0}, Map.take(tile_b, [:character, :color, :background_color, :state, :script]))])
 
-    rows = dungeon_as_table(Repo.preload(map, :dungeon_map_tiles), true)
+    rows = dungeon_as_table(Repo.preload(map, :dungeon_map_tiles), map.width, map.height, true)
 
     assert rows =~ ~r|<td id='1_1' data-color='' data-background-color='' data-tile-template-id='#{tile_a.id}'><div>A</div></td>|
     assert rows =~ ~r|<td id='1_2' data-color='' data-background-color='' data-tile-template-id='#{tile_a.id}'><div>A</div></td>|

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 ExUnit.start
+ExUnit.start(capture_log: true)
 
 Ecto.Adapters.SQL.Sandbox.mode(DungeonCrawl.Repo, :manual)
 


### PR DESCRIPTION
Adding dungeon instance processes and a registry. The instance process holds the state of a dungeon instance (map, running programs, etc) and updates the backing database periodically.
This makes it easier for a scripted map tile to have a program that runs for it, moving it, responding to events, etc.