### PR TITLE
Dungeon instances tweaks

### DIFF
--- a/lib/dungeon_crawl/dungeon_processes/instances.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instances.ex
@@ -70,6 +70,19 @@ defmodule DungeonCrawl.DungeonProcesses.Instances do
   end
 
   @doc """
+  Gets the player location, returns nil if one is not found. Uses a map with an `id` key to lookup based on the map tile
+  associated with that location. Otherwise lookup is done based on user_id_hash when the parameter is a binary.
+  """
+  def get_player_location(%Instances{player_locations: player_locations} = _state, %{id: map_tile_id}) do
+    player_locations[map_tile_id]
+  end
+  def get_player_location(%Instances{player_locations: player_locations} = _state, user_id_hash) do
+    player_locations
+    |> Map.values
+    |> Enum.find(fn location -> location.user_id_hash == user_id_hash end)
+  end
+
+  @doc """
   Returns true or false, depending on if the given tile_id responds to the event.
   """
   def responds_to_event?(%Instances{program_contexts: program_contexts} = _state, %{id: map_tile_id}, event) do

--- a/test/dungeon_crawl/dungeon_processes/instances_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instances_test.exs
@@ -76,6 +76,20 @@ defmodule DungeonCrawl.DungeonProcesses.InstancesTest do
     assert %{id: 999} = Instances.get_map_tile_by_id(state, %{id: 999})
   end
 
+  test "get_player_location/2", %{state: state} do
+    player_tile = %{id: 1, row: 4, col: 4, z_index: 1, character: "@", state: "", script: ""}
+    location = %Location{user_id_hash: "dubs", map_tile_instance_id: 123}
+    {player_tile, state} = Instances.create_player_map_tile(state, player_tile, location)
+
+    # using a map tile id
+    assert Instances.get_player_location(state, %{id: player_tile.id}) == location
+    refute Instances.get_player_location(state, %{id: 99999})
+
+    # using user_id_hash
+    assert Instances.get_player_location(state, "dubs") == location
+    refute Instances.get_player_location(state, "notrealhash")
+  end
+
   test "responds_to_event?/3", %{state: state} do
     assert Instances.responds_to_event?(state, %{id: 999}, "TOUCH")
     refute Instances.responds_to_event?(state, %{id: 999}, "SNIFF")

--- a/test/dungeon_crawl_web/controllers/crawler_controller_test.exs
+++ b/test/dungeon_crawl_web/controllers/crawler_controller_test.exs
@@ -179,11 +179,8 @@ defmodule DungeonCrawlWeb.CrawlerControllerTest do
   test "does not destroy current instance if others are crawling", %{conn: conn, user: user} do
     instance = insert_stubbed_dungeon_instance(%{active: true})
     different_user = insert_user(%{username: "someoneelse", user_id_hash: "different dude"})
-    insert_player_location(%{map_instance_id: instance.id, user_id_hash: user.user_id_hash})
-    insert_player_location(%{map_instance_id: instance.id, user_id_hash: different_user.user_id_hash})
-    # Seems that it might not be done propagating the instance_process, below sometimes fails with nil at the delete spot
-    # TODO: remove the sleep, probably after most of the casts have been converted to calls
-    :timer.sleep(100)
+    insert_player_location(%{map_instance_id: instance.id, user_id_hash: user.user_id_hash, row: 2, z_index: 1})
+    insert_player_location(%{map_instance_id: instance.id, user_id_hash: different_user.user_id_hash, row: 3, z_index: 1})
     conn = delete conn, crawler_path(conn, :destroy)
     assert redirected_to(conn) == crawler_path(conn, :show)
     assert get_flash(conn, :info) == "Dungeon cleared."


### PR DESCRIPTION
Dungeon channel no longer hitting the DB for every lookup of a player's location.
Fixing a flakey test.