### PR TITLE
Use wait instead of idle for programs added/replaced via a become com…

### DIFF
--- a/lib/dungeon_crawl/dungeon_processes/instances.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instances.ex
@@ -256,7 +256,7 @@ defmodule DungeonCrawl.DungeonProcesses.Instances do
   defp _update_program(previous_program, {:ok, map_tile, state}) do
     new_program = state.program_contexts[map_tile.id].program
                   |> Map.merge(Map.take(previous_program, [:broadcasts, :responses]))
-                  |> Map.put(:status, :idle)
+                  |> Map.put(:status, :wait)
 
     updated_context = %{ state.program_contexts[map_tile.id] | program: new_program }
 

--- a/test/dungeon_crawl/dungeon_processes/instances_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instances_test.exs
@@ -265,7 +265,7 @@ defmodule DungeonCrawl.DungeonProcesses.InstancesTest do
              locked: false,
              pc: 1,
              responses: [],
-             status: :idle,
+             status: :wait,
              wait_cycles: 0
            } = program
 
@@ -284,7 +284,7 @@ defmodule DungeonCrawl.DungeonProcesses.InstancesTest do
              locked: false,
              pc: 1,
              responses: [],
-             status: :idle,
+             status: :wait,
              wait_cycles: 0
            } = program
   end


### PR DESCRIPTION
…mand, so they will be able to run right away and not have to wait for a message