### PR TITLE
Additional state stuff

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -917,6 +917,61 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@npmcli/move-file": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
+      "integrity": "sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
+      "dev": true
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
@@ -1154,12 +1209,6 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
-    "ansi-colors": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
-      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
-      "dev": true
-    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -1230,18 +1279,9 @@
       "dev": true
     },
     "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
     "array-unique": {
@@ -1596,29 +1636,6 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
-    "cacache": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
-      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
-      }
-    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -1914,32 +1931,177 @@
       "dev": true
     },
     "copy-webpack-plugin": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
-      "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.0.3.tgz",
+      "integrity": "sha512-q5m6Vz4elsuyVEIUXr7wJdIdePWTubsqVbEMvf1WQnHGv0Q+9yPRu7MtYFPt+GBOXRav9lvIINifTQ1vSCs+eA==",
       "dev": true,
       "requires": {
-        "cacache": "^12.0.3",
-        "find-cache-dir": "^2.1.0",
-        "glob-parent": "^3.1.0",
-        "globby": "^7.1.1",
-        "is-glob": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "minimatch": "^3.0.4",
+        "cacache": "^15.0.4",
+        "fast-glob": "^3.2.4",
+        "find-cache-dir": "^3.3.1",
+        "glob-parent": "^5.1.1",
+        "globby": "^11.0.1",
+        "loader-utils": "^2.0.0",
         "normalize-path": "^3.0.0",
-        "p-limit": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
-        "webpack-log": "^2.0.0"
+        "p-limit": "^3.0.1",
+        "schema-utils": "^2.7.0",
+        "serialize-javascript": "^4.0.0",
+        "webpack-sources": "^1.4.3"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "cacache": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+          "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
+          "dev": true,
+          "requires": {
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "glob": "^7.1.4",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.1",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.0",
+            "tar": "^6.0.2",
+            "unique-filename": "^1.1.1"
+          }
+        },
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "find-cache-dir": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+          "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
         "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "p-try": {
@@ -1948,16 +2110,70 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
           "dev": true,
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
+            "find-up": "^4.0.0"
           }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "ssri": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+          "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -2365,12 +2581,12 @@
       }
     },
     "dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "requires": {
-        "path-type": "^3.0.0"
+        "path-type": "^4.0.0"
       }
     },
     "dom-serializer": {
@@ -2776,10 +2992,87 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -3586,25 +3879,17 @@
       "dev": true
     },
     "globby": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
       }
     },
     "graceful-fs": {
@@ -3758,9 +4043,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
     "import-fresh": {
@@ -4075,12 +4360,6 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4100,11 +4379,12 @@
       "dev": true
     },
     "jest-worker": {
-      "version": "25.2.6",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.2.6.tgz",
-      "integrity": "sha512-FJn9XDUSxcOR4cwDzRfL1z56rUofNTFs539FGASpd50RHdb6EVkhxQqktodW2mI49l+W3H+tFJDotCHUQF6dmA==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+      "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
       "dev": true,
       "requires": {
+        "@types/node": "*",
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       },
@@ -4352,6 +4632,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -4440,9 +4726,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -4475,12 +4761,30 @@
       }
     },
     "minipass-pipeline": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
-      "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "mississippi": {
@@ -4838,9 +5142,9 @@
       }
     },
     "p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
@@ -4942,21 +5246,10 @@
       "dev": true
     },
     "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -4976,6 +5269,12 @@
     },
     "phoenix_html": {
       "version": "file:../deps/phoenix_html"
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -5918,6 +6217,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rgb-regex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -5948,6 +6253,12 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -5992,12 +6303,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
-    },
-    "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
     "set-blocking": {
@@ -6084,9 +6389,9 @@
       }
     },
     "slash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
     "snapdragon": {
@@ -6487,67 +6792,99 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
     },
-    "terser": {
-      "version": "4.6.11",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.11.tgz",
-      "integrity": "sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==",
+    "tar": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+      "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
       "dev": true,
       "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
       }
     },
     "terser-webpack-plugin": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.5.tgz",
-      "integrity": "sha512-WlWksUoq+E4+JlJ+h+U+QUzXpcsMSSNXkDy9lBVkSqDn1w23Gg29L/ary9GeJVYCGiNJJX7LnVc4bwL1N3/g1w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-4.1.0.tgz",
+      "integrity": "sha512-0ZWDPIP8BtEDZdChbufcXUigOYk6dOX/P/X0hWxqDDcVAQLb8Yy/0FAaemSfax3PAA67+DJR778oz8qVbmy4hA==",
       "dev": true,
       "requires": {
-        "cacache": "^13.0.1",
-        "find-cache-dir": "^3.2.0",
-        "jest-worker": "^25.1.0",
-        "p-limit": "^2.2.2",
-        "schema-utils": "^2.6.4",
-        "serialize-javascript": "^2.1.2",
+        "cacache": "^15.0.5",
+        "find-cache-dir": "^3.3.1",
+        "jest-worker": "^26.3.0",
+        "p-limit": "^3.0.2",
+        "schema-utils": "^2.6.6",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
-        "terser": "^4.4.3",
+        "terser": "^5.0.0",
         "webpack-sources": "^1.4.3"
       },
       "dependencies": {
-        "cacache": {
-          "version": "13.0.1",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
-          "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+        "ajv": {
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
           "dev": true,
           "requires": {
-            "chownr": "^1.1.2",
-            "figgy-pudding": "^3.5.1",
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "cacache": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+          "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
+          "dev": true,
+          "requires": {
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.2.2",
             "infer-owner": "^1.0.4",
-            "lru-cache": "^5.1.1",
-            "minipass": "^3.0.0",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.1",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "p-map": "^3.0.0",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
-            "rimraf": "^2.7.1",
-            "ssri": "^7.0.0",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.0",
+            "tar": "^6.0.2",
             "unique-filename": "^1.1.1"
           }
+        },
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
         },
         "find-cache-dir": {
           "version": "3.3.1",
@@ -6579,19 +6916,34 @@
             "p-locate": "^4.1.0"
           }
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
           }
         },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
         "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -6604,6 +6956,17 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
+          },
+          "dependencies": {
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            }
           }
         },
         "p-try": {
@@ -6627,11 +6990,40 @@
             "find-up": "^4.0.0"
           }
         },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -6640,14 +7032,30 @@
           "dev": true
         },
         "ssri": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-          "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+          "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
           "dev": true,
           "requires": {
-            "figgy-pudding": "^3.5.1",
             "minipass": "^3.1.1"
           }
+        },
+        "terser": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.1.0.tgz",
+          "integrity": "sha512-pwC1Jbzahz1ZPU87NQ8B3g5pKbhyJSiHih4gLH6WZiPU8mmS1IlGbB0A2Nuvkj/LCNsgIKctg6GkYwWCeTvXZQ==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
@@ -6943,12 +7351,6 @@
         "object.getownpropertydescriptors": "^2.1.0"
       }
     },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
-    },
     "v8-compile-cache": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
@@ -7027,20 +7429,80 @@
           "dev": true
         },
         "terser-webpack-plugin": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-          "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+          "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
           "dev": true,
           "requires": {
             "cacache": "^12.0.2",
             "find-cache-dir": "^2.1.0",
             "is-wsl": "^1.1.0",
             "schema-utils": "^1.0.0",
-            "serialize-javascript": "^2.1.2",
+            "serialize-javascript": "^4.0.0",
             "source-map": "^0.6.1",
             "terser": "^4.1.2",
             "webpack-sources": "^1.4.0",
             "worker-farm": "^1.7.0"
+          },
+          "dependencies": {
+            "cacache": {
+              "version": "12.0.4",
+              "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+              "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+              "dev": true,
+              "requires": {
+                "bluebird": "^3.5.5",
+                "chownr": "^1.1.1",
+                "figgy-pudding": "^3.5.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.1.15",
+                "infer-owner": "^1.0.3",
+                "lru-cache": "^5.1.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.3",
+                "ssri": "^6.0.1",
+                "unique-filename": "^1.1.1",
+                "y18n": "^4.0.0"
+              }
+            },
+            "is-wsl": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+              "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+              "dev": true
+            },
+            "serialize-javascript": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+              "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+              "dev": true,
+              "requires": {
+                "randombytes": "^2.1.0"
+              }
+            },
+            "terser": {
+              "version": "4.8.0",
+              "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+              "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+              "dev": true,
+              "requires": {
+                "commander": "^2.20.0",
+                "source-map": "~0.6.1",
+                "source-map-support": "~0.5.12"
+              }
+            },
+            "worker-farm": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+              "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+              "dev": true,
+              "requires": {
+                "errno": "~0.1.7"
+              }
+            }
           }
         }
       }
@@ -7103,16 +7565,6 @@
         }
       }
     },
-    "webpack-log": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
-      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
-      }
-    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -7145,15 +7597,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
-    },
-    "worker-farm": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
-      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
-      "dev": true,
-      "requires": {
-        "errno": "~0.1.7"
-      }
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -18,11 +18,11 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.0",
-    "copy-webpack-plugin": "^5.1.1",
+    "copy-webpack-plugin": "^6.0.3",
     "css-loader": "3.3.0",
     "mini-css-extract-plugin": "^0.4.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
-    "terser-webpack-plugin": "^2.3.5",
+    "terser-webpack-plugin": "^4.1.0",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.9"
   }

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = (env, options) => ({
   },
   plugins: [
     new MiniCssExtractPlugin({ filename: '../css/app.css' }),
-    new CopyWebpackPlugin([{ from: 'static/', to: '../' }]),
+    new CopyWebpackPlugin({patterns: [{ from: 'static/', to: '../' }]}),
     new webpack.ProvidePlugin({
       // add jquery
       $: 'jquery',

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -175,6 +175,7 @@ defmodule DungeonCrawl.Scripting.Command do
   """
   def change_state(%Runner{object_id: object_id, state: state} = runner_state, params) do
     [var, op, value] = params
+    value = resolve_variable(runner_state, value)
 
     object = Instances.get_map_tile_by_id(state, %{id: object_id})
     object_state = Map.put(object.parsed_state, var, Maths.calc(object.parsed_state[var] || 0, op, value))
@@ -1041,6 +1042,9 @@ defmodule DungeonCrawl.Scripting.Command do
   end
   def send_message(%Runner{} = runner_state, [label, target]) do
     _send_message(runner_state, [label, String.downcase(target)])
+  end
+  defp _send_message(%Runner{} = runner_state, [label, target]) when is_integer(target) do
+    _send_message_via_ids(runner_state, label, [target])
   end
   defp _send_message(%Runner{state: state, object_id: object_id} = runner_state, [label, "self"]) do
     object = Instances.get_map_tile_by_id(state, %{id: object_id})

--- a/lib/dungeon_crawl/scripting/direction.ex
+++ b/lib/dungeon_crawl/scripting/direction.ex
@@ -121,6 +121,8 @@ defmodule DungeonCrawl.Scripting.Direction do
     "north"
     iex> Direction.change_direction("idle", "counterclockwise")
     "idle"
+    iex> Direction.change_direction("north", "notavalidrotation")
+    "north"
   """
   def change_direction(direction, change_by) do
     @orthogonal_change[change_by][normalize_orthogonal(direction)] || direction || "idle"

--- a/lib/dungeon_crawl/scripting/parser.ex
+++ b/lib/dungeon_crawl/scripting/parser.ex
@@ -190,6 +190,7 @@ defmodule DungeonCrawl.Scripting.Parser do
 
   defp _cast_other_target(param) do
     cond do
+      Regex.match?(~r/^sender$|^$/, param) -> [:event_sender]
       Regex.match?(~r/^\d+$/, param) -> String.to_integer(param)
       Regex.match?(~r/^@.+?$/, param) -> _normalize_state_arg(param)
       Regex.match?(~r/^\?.+?$/i, param) -> _normalize_special_var(param)

--- a/lib/dungeon_crawl/scripting/parser.ex
+++ b/lib/dungeon_crawl/scripting/parser.ex
@@ -299,6 +299,13 @@ defmodule DungeonCrawl.Scripting.Parser do
 
   defp _normalize_state_arg(arg) do
     case Regex.named_captures(~r/^(?<type>\?.*?@|@@|@)(?<state_element>[_A-Za-z0-9]+?)\s*?(\+\s?(?<concat>[_A-Za-z0-9]+?))?\s*$/i, String.trim(arg)) do
+      %{"type" => "?random@", "state_element" => number} ->
+        if Regex.match?(~r/^\d{1,3}$/, number) do
+          {:random, 1..String.to_integer(number)}
+        else
+          :error
+        end
+
       %{"type" => type, "state_element" => state_element, "concat" => ""} ->
         {_state_var_type(type), String.trim(state_element) |> String.to_atom()}
 

--- a/lib/dungeon_crawl/scripting/program_validator.ex
+++ b/lib/dungeon_crawl/scripting/program_validator.ex
@@ -92,7 +92,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidator do
   end
 
   defp _validate(program, [ {line_no, [:go, [direction] ]} | instructions], errors, user) do
-    if @valid_directions |> Enum.member?(direction) do
+    if @valid_directions |> Enum.member?(direction) or is_tuple(direction) do
       _validate(program, instructions, errors, user)
     else
       _validate(program, instructions, ["Line #{line_no}: GO command references invalid direction `#{direction}`" | errors], user)
@@ -122,7 +122,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidator do
     _validate(program, [ {line_no, [:move, [direction, false] ]} | instructions], errors, user)
   end
   defp _validate(program, [ {line_no, [:move, [direction, _] ]} | instructions], errors, user) do
-    if @valid_directions |> Enum.member?(direction) do
+    if @valid_directions |> Enum.member?(direction) or is_tuple(direction) do
       _validate(program, instructions, errors, user)
     else
       _validate(program, instructions, ["Line #{line_no}: MOVE command references invalid direction `#{direction}`" | errors], user)
@@ -205,7 +205,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidator do
     errors = unless is_number(amount) and amount > 0,
                do: ["Line #{line_no}: TAKE command has invalid amount `#{amount}`" | errors],
                else: errors
-    errors = unless who == [:event_sender] or Enum.member?(@valid_directions -- ["idle"], who),
+    errors = unless who == [:event_sender] or Enum.member?(@valid_directions -- ["idle"], who) or is_tuple(who),
                do: ["Line #{line_no}: TAKE command references invalid direction `#{who}`" | errors],
                else: errors
     _validate(program, instructions, errors, user)
@@ -215,7 +215,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidator do
     errors = unless is_number(amount) and amount > 0 || is_tuple(amount),
                do: ["Line #{line_no}: TAKE command has invalid amount `#{amount}`" | errors],
                else: errors
-    errors = unless who == [:event_sender] or Enum.member?(@valid_directions -- ["idle"], who),
+    errors = unless who == [:event_sender] or Enum.member?(@valid_directions -- ["idle"], who) or is_tuple(who),
                do: ["Line #{line_no}: TAKE command references invalid direction `#{who}`" | errors],
                else: errors
     errors = unless Program.line_for(program, label),
@@ -225,7 +225,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidator do
   end
 
   defp _validate(program, [ {line_no, [:try, [direction] ]} | instructions], errors, user) do
-    if @valid_directions |> Enum.member?(direction) do
+    if @valid_directions |> Enum.member?(direction) or is_tuple(direction) do
       _validate(program, instructions, errors, user)
     else
       _validate(program, instructions, ["Line #{line_no}: TRY command references invalid direction `#{direction}`" | errors], user)

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -55,6 +55,8 @@ Logger.info inspect params
 Logger.info inspect object
 if object, do: Logger.info inspect object.state
 Logger.info inspect runner_state.event_sender
+Logger.info "instance state:"
+Logger.info inspect state.state_values
 end
         runner_state = apply(Command, command, [runner_state, params])
 

--- a/lib/dungeon_crawl/scripting/variable_resolution.ex
+++ b/lib/dungeon_crawl/scripting/variable_resolution.ex
@@ -40,12 +40,32 @@ defmodule DungeonCrawl.Scripting.VariableResolution do
     object = Instances.get_map_tile_by_id(state, %{id: object_id})
     object.name
   end
+  def resolve_variable(%Runner{state: state, object_id: object_id}, {:state_variable, :row}) do
+    object = Instances.get_map_tile_by_id(state, %{id: object_id})
+    object.row
+  end
+  def resolve_variable(%Runner{state: state, object_id: object_id}, {:state_variable, :col}) do
+    object = Instances.get_map_tile_by_id(state, %{id: object_id})
+    object.col
+  end
   def resolve_variable(%Runner{state: state, object_id: object_id}, {:state_variable, var}) do
     object = Instances.get_map_tile_by_id(state, %{id: object_id})
     object.parsed_state[var]
   end
   def resolve_variable(%Runner{event_sender: event_sender}, {:event_sender_variable, var}) do
     event_sender && event_sender.parsed_state[var]
+  end
+  def resolve_variable(%Runner{}, {:instance_state_variable, :north_edge}) do
+    0
+  end
+  def resolve_variable(%Runner{}, {:instance_state_variable, :west_edge}) do
+    0
+  end
+  def resolve_variable(%Runner{state: state}, {:instance_state_variable, :east_edge}) do
+    state.state_values[:cols] - 1
+  end
+  def resolve_variable(%Runner{state: state}, {:instance_state_variable, :south_edge}) do
+    state.state_values[:rows] - 1
   end
   def resolve_variable(%Runner{state: state}, {:instance_state_variable, var}) do
     state.state_values[var]

--- a/lib/dungeon_crawl/scripting/variable_resolution.ex
+++ b/lib/dungeon_crawl/scripting/variable_resolution.ex
@@ -21,6 +21,9 @@ defmodule DungeonCrawl.Scripting.VariableResolution do
       resolved_variable
     end
   end
+  def resolve_variable(%Runner{state: state, object_id: object_id}, {:state_variable, :id}) do
+    object_id
+  end
   def resolve_variable(%Runner{state: state, object_id: object_id}, {:state_variable, :character}) do
     object = Instances.get_map_tile_by_id(state, %{id: object_id})
     object.character

--- a/lib/dungeon_crawl/scripting/variable_resolution.ex
+++ b/lib/dungeon_crawl/scripting/variable_resolution.ex
@@ -4,6 +4,7 @@ defmodule DungeonCrawl.Scripting.VariableResolution do
   """
 
   alias DungeonCrawl.DungeonProcesses.Instances
+  alias DungeonCrawl.Scripting.Direction
   alias DungeonCrawl.Scripting.Runner
 
   def resolve_variable_map(%Runner{} = runner_state, variable_map) when is_map(variable_map) do
@@ -46,9 +47,17 @@ defmodule DungeonCrawl.Scripting.VariableResolution do
   def resolve_variable(%Runner{state: state}, {:instance_state_variable, var}) do
     state.state_values[var]
   end
+  def resolve_variable(%Runner{} = runner_state, {{:state_variable, state_var}, var}) do
+    direction = resolve_variable(runner_state, {:state_variable, state_var})
+    resolve_variable(runner_state, {{:direction, direction}, var})
+  end
   def resolve_variable(%Runner{state: state, object_id: object_id}, {{:direction, direction}, var}) do
     base = Instances.get_map_tile_by_id(state, %{id: object_id})
-    object = Instances.get_map_tile(state, base, direction)
+    object = if Direction.valid_orthogonal_change?(direction) do
+               Instances.get_map_tile(state, base, Direction.change_direction(base.parsed_state[:facing], direction))
+             else
+               Instances.get_map_tile(state, base, direction)
+             end
     object && resolve_variable(%Runner{state: state, object_id: object.id}, {:state_variable, var})
   end
   def resolve_variable(%Runner{}, literal) do

--- a/lib/dungeon_crawl/scripting/variable_resolution_stub.ex
+++ b/lib/dungeon_crawl/scripting/variable_resolution_stub.ex
@@ -38,11 +38,29 @@ defmodule DungeonCrawl.Scripting.VariableResolutionStub do
   def resolve_variable(%{}, {:state_variable, :name}) do
     "Test Stub"
   end
+  def resolve_variable(%{}, {:state_variable, :row}) do
+    2
+  end
+  def resolve_variable(%{}, {:state_variable, :col}) do
+    4
+  end
   def resolve_variable(%{}, {:state_variable, _var}) do
     "."
   end
   def resolve_variable(%{}, {:event_sender_variable, _var}) do
     "from sender"
+  end
+  def resolve_variable(%{}, {:instance_state_variable, :north_edge}) do
+    0
+  end
+  def resolve_variable(%{}, {:instance_state_variable, :west_edge}) do
+    0
+  end
+  def resolve_variable(%{}, {:instance_state_variable, :east_edge}) do
+    29
+  end
+  def resolve_variable(%{}, {:instance_state_variable, :south_edge}) do
+    19
   end
   def resolve_variable(%{}, {:instance_state_variable, _var}) do
     "from the instance"

--- a/lib/dungeon_crawl/scripting/variable_resolution_stub.ex
+++ b/lib/dungeon_crawl/scripting/variable_resolution_stub.ex
@@ -23,6 +23,9 @@ defmodule DungeonCrawl.Scripting.VariableResolutionStub do
       resolved_variable
     end
   end
+  def resolve_variable(%{}, {:state_variable, :id}) do
+    12345
+  end
   def resolve_variable(%{}, {:state_variable, :character}) do
     "X"
   end

--- a/lib/dungeon_crawl/tile_templates/tile_seeder.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder.ex
@@ -26,6 +26,7 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder do
     fake_wall()
 
     # creatures
+    bandit()
     expanding_foam()
     pede_head()
     pede_body()

--- a/lib/dungeon_crawl/tile_templates/tile_seeder/block_walls.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder/block_walls.ex
@@ -2,7 +2,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.BlockWalls do
   alias DungeonCrawl.TileTemplates
 
   def solid_wall() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "solid_wall",
       %{character: "█",
         name: "Solid Wall",
         description: "A solid wall",
@@ -13,7 +14,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.BlockWalls do
   end
 
   def normal_wall() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "normal_wall",
       %{character: "▒",
         name: "Normal Wall",
         description: "A normal wall",
@@ -24,7 +26,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.BlockWalls do
   end
 
   def breakable_wall() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "breakable_wall",
       %{character: "░",
         name: "Breakable Wall",
         description: "A breakable wall",
@@ -35,7 +38,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.BlockWalls do
   end
 
   def fake_wall() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "fake_wall",
       %{character: "▒",
         name: "Fake Wall",
         description: "A fake wall",

--- a/lib/dungeon_crawl/tile_templates/tile_seeder/color_doors.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder/color_doors.ex
@@ -4,7 +4,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.ColorDoors do
   def color_keys_and_doors() do
     ["red", "green", "blue", "gray", "purple", "orange"]
     |> Enum.map(fn color ->
-      TileTemplates.find_or_create_tile_template!(
+      TileTemplates.update_or_create_tile_template!(
+        "#{color}_key",
         %{character: "♀",
           name: "#{color} key",
           description: "a #{color} key",
@@ -25,7 +26,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.ColorDoors do
                   """
       })
 
-      TileTemplates.find_or_create_tile_template!(
+      TileTemplates.update_or_create_tile_template!(
+        "#{color}_door",
         %{character: "∙",
           name: "#{color} door",
           description: "a #{color} door",
@@ -50,7 +52,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.ColorDoors do
   end
 
   def generic_colored_key() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "colored_key",
       %{character: "♀",
         name: "Colored Key",
         description: "A key that can have a color and unlock a matching door",
@@ -73,7 +76,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.ColorDoors do
   end
 
   def generic_colored_door() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "colored_door",
       %{character: "∙",
         name: "Colored Door",
         description: "A door that can have a color and be unlocked by a matching key",

--- a/lib/dungeon_crawl/tile_templates/tile_seeder/creatures.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder/creatures.ex
@@ -2,7 +2,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
   alias DungeonCrawl.TileTemplates
 
   def bandit do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "bandit",
       %{character: "♣",
         name: "Bandit",
         description: "It runs around",
@@ -37,7 +38,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
   end
 
   def expanding_foam do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "expanding_foam",
       %{character: "*",
         name: "Expanding Foam",
         description: "It gets all over",
@@ -67,7 +69,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
   end
 
   def pede_head do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "pedehead",
       %{character: "ϴ",
         name: "PedeHead",
         description: "Centipede head",
@@ -105,7 +108,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
   end
 
   def pede_body do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "pedebody",
       %{character: "O",
         name: "PedeBody",
         description: "Centipede body segment",

--- a/lib/dungeon_crawl/tile_templates/tile_seeder/creatures.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder/creatures.ex
@@ -1,6 +1,41 @@
 defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
   alias DungeonCrawl.TileTemplates
 
+  def bandit do
+    TileTemplates.find_or_create_tile_template!(
+      %{character: "♣",
+        name: "Bandit",
+        description: "It runs around",
+        state: "blocking: true, destroyable: true, pushable: true",
+        color: "maroon",
+        public: true,
+        active: true,
+        script: """
+                :THUD
+                :NEW_SPEED
+                #RANDOM wait_cycles, 2-5
+                :NEW_DIRECTION
+                #RANDOM direction, north, south, east, west, player, player
+                #RANDOM steps, 2-5
+                :MOVING
+                #IF ?{@facing}@player, HURT_PLAYER
+                #TRY @direction
+                @steps -= 1
+                #IF @steps > 0, MOVING
+                #IF ?random@4 == 1, NEW_SPEED
+                #SEND NEW_DIRECTION
+                #END
+                :TOUCH
+                #IF not ?sender@player, NEW_DIRECTION
+                #TAKE health, 10, ?sender
+                #DIE
+                :HURT_PLAYER
+                #TAKE health, 10, @facing
+                #DIE
+                """
+    })
+  end
+
   def expanding_foam do
     TileTemplates.find_or_create_tile_template!(
       %{character: "*",
@@ -114,6 +149,7 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
 
   defmacro __using__(_params) do
     quote do
+      def bandit(), do: unquote(__MODULE__).bandit()
       def expanding_foam(), do: unquote(__MODULE__).expanding_foam()
       def pede_head(), do: unquote(__MODULE__).pede_head()
       def pede_body(), do: unquote(__MODULE__).pede_body()

--- a/lib/dungeon_crawl/tile_templates/tile_seeder/creatures.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder/creatures.ex
@@ -42,13 +42,12 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
         script: """
                 :main
                 #pull @facing
+                #if ?{@facing}@blocking, thud
                 #send main
                 #end
                 :thud
-                #if not ?north@blocking,not_surrounded
-                #if not ?south@blocking,not_surrounded
-                #if not ?east@blocking,not_surrounded
-                #if not ?west@blocking,not_surrounded
+                #if not ?clockwise@blocking,not_surrounded
+                #if not ?counterclockwise@blocking,not_surrounded
                 #send surrounded
                 #end
                 :not_surrounded

--- a/lib/dungeon_crawl/tile_templates/tile_seeder/creatures.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder/creatures.ex
@@ -71,7 +71,7 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
       %{character: "ϴ",
         name: "PedeHead",
         description: "Centipede head",
-        state: "blocking: true, facing: south",
+        state: "blocking: true, facing: south, pulling: map_tile_id",
         public: true,
         active: true,
         script: """
@@ -81,8 +81,10 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
                 #send main
                 #end
                 :thud
+                #if @pulling == false, not_surrounded
                 #if not ?clockwise@blocking,not_surrounded
                 #if not ?counterclockwise@blocking,not_surrounded
+                #if not ?reverse@blocking,not_surrounded
                 #send surrounded
                 #end
                 :not_surrounded
@@ -91,13 +93,13 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
                 #end
                 :shot
                 #facing reverse
-                #send pede_died, @facing
+                #send pede_died, @pulling
                 #die
                 #end
                 :surrounded
                 #facing reverse
-                #send surrounded, @facing
-                #become slug: pedebody, color: @color, background_color: @background_color
+                #send surrounded, @pulling
+                #become slug: pedebody, color: @color, background_color: @background_color, pulling: false, pullable: @pulling
                 """
     })
   end
@@ -107,41 +109,30 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Creatures do
       %{character: "O",
         name: "PedeBody",
         description: "Centipede body segment",
-        state: "pullable: map_tile_id, pulling: true, blocking: true, facing: west",
+        state: "pullable: map_tile_id, pulling: map_tile_id, blocking: true, facing: west",
         public: true,
         active: true,
         script: """
                 #end
                 :shot
                 #facing reverse
-                #send pede_died, @facing
+                #send pede_died, @pulling
                 ?i
                 #die
-                :pede_died
-                #become slug: pedehead, facing: @facing, pullable: false, color: @color, background_color: @background_color
-                #end
                 :surrounded
                 #facing reverse
-                @pullable = map_tile_id
-                #if @facing == west, checkwest
-                #if @facing == south, checksouth
-                #if @facing == north, checknorth
-                :checkeast
-                #if ?east@name == PedeBody, not_tail
-                #send tail
-                :checkwest
-                #if ?west@name == PedeBody, not_tail
-                #send tail
-                :checksouth
-                #if ?south@name == PedeBody, not_tail
-                #send tail
-                :checknorth
-                #if ?north@name == PedeBody, not_tail
+                #if @pulling != false, not_tail
                 :tail
-                #become slug: pedehead, facing: @facing, pullable: false, color: @color, background_color: @background_color
+                #become slug: pedehead, facing: @facing, color: @color, background_color: @background_color, pullable: false, pulling: @pullable
+                #end
+                :pede_died
+                #become slug: pedehead, facing: @facing, color: @color, background_color: @background_color, pullable: false, pulling: @pulling
                 #end
                 :not_tail
-                #send surrounded, @facing
+                @tmp = @pulling
+                @pulling = @pullable
+                @pullable = @tmp
+                #send surrounded, @pullable
                 #end
                 """
     })

--- a/lib/dungeon_crawl/tile_templates/tile_seeder/ordinance.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder/ordinance.ex
@@ -2,7 +2,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Ordinance do
   alias DungeonCrawl.TileTemplates
 
   def smoke do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "smoke",
       %{character: "▒",
         name: "Smoke",
         description: "Fine particles of various dust and gas",

--- a/lib/dungeon_crawl/tile_templates/tile_seeder/terrain.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder/terrain.ex
@@ -2,10 +2,11 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Terrain do
   alias DungeonCrawl.TileTemplates
 
   def boulder() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "boulder",
       %{character: "▪",
         name: "Boulder",
-        description: "A boulder",
+        description: "A smooth boulder",
         state: "blocking: true, pushable: true, pullable: true",
         public: true,
         active: true
@@ -13,7 +14,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Terrain do
   end
 
   def counter_clockwise_conveyor() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "counter_clockwise_conveyor",
       %{character: "/",
         name: "Counter Clockwise Conveyor",
         description: "Rotates things around it in a counter clockwise direction",
@@ -41,7 +43,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Terrain do
   end
 
   def clockwise_conveyor() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "clockwise_conveyor",
       %{character: "\\",
         name: "Clockwise Conveyor",
         description: "Rotates things around it in a clockwise direction",
@@ -69,7 +72,8 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.Terrain do
   end
 
   def grave() do
-    TileTemplates.find_or_create_tile_template!(
+    TileTemplates.update_or_create_tile_template!(
+      "grave",
       %{character: "✝",
         name: "Grave",
         description: "It looks fresh. R.I.P.",

--- a/lib/dungeon_crawl/tile_templates/tile_templates.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_templates.ex
@@ -244,6 +244,45 @@ defmodule DungeonCrawl.TileTemplates do
   end
 
   @doc """
+  Finds and updates or creates a tile_template; mainly useful for the initial seeds.
+  Looks up the tile first by slug (if given). If one is found, and the latest
+  When one is found, the newest tile_template will be returned (ie, last created, even
+  if not active) to ensure get the latest version of the seeded tile. If nothing with that slug
+  is found, falls back to the "find_or_create_tile_template" function.
+
+  Does not accept attributes of `nil`
+
+  ## Examples
+
+      iex> update_or_create_tile_template(%{field: value})
+      {:ok, %TileTemplate{}}
+
+      iex> update_or_create_tile_template(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_or_create_tile_template(slug, attrs) do
+    existing_template = Repo.one(from tt in TileTemplate, where: tt.slug == ^slug, limit: 1, order_by: [desc: :id])
+
+    if existing_template do
+      update_tile_template(existing_template, attrs)
+    else
+      find_or_create_tile_template(attrs)
+    end
+  end
+
+  def update_or_create_tile_template!(slug, attrs) do
+    existing_template = Repo.one(from tt in TileTemplate, where: tt.slug == ^slug, limit: 1, order_by: [desc: :id])
+
+    if existing_template do
+      {:ok, updated_template} = update_tile_template(existing_template, attrs)
+      updated_template
+    else
+      find_or_create_tile_template!(attrs)
+    end
+  end
+
+  @doc """
   Updates a tile_template.
 
   ## Examples

--- a/lib/dungeon_crawl/tile_templates/tile_templates.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_templates.ex
@@ -20,16 +20,19 @@ defmodule DungeonCrawl.TileTemplates do
   def list_tile_templates(%DungeonCrawl.Account.User{} = user) do
     Repo.all(from t in TileTemplate,
              where: t.user_id == ^user.id,
-             where: is_nil(t.deleted_at))
+             where: is_nil(t.deleted_at),
+             order_by: :slug)
   end
   def list_tile_templates(:nouser) do
     Repo.all(from t in TileTemplate,
              where: is_nil(t.user_id),
-             where: is_nil(t.deleted_at))
+             where: is_nil(t.deleted_at),
+             order_by: :slug)
   end
   def list_tile_templates() do
     Repo.all(from t in TileTemplate,
-             where: is_nil(t.deleted_at))
+             where: is_nil(t.deleted_at),
+             order_by: :slug)
   end
 
   @doc """

--- a/lib/dungeon_crawl_web/templates/page/reference.html.eex
+++ b/lib/dungeon_crawl_web/templates/page/reference.html.eex
@@ -397,6 +397,17 @@
           <pre class="script">#PUT slug: wall, row: 1, col: 1</pre></td>
     </tr>
     <tr>
+      <td>RANDOM</td>
+      <td>list - 2 or more</td>
+      <td>Sets the specified state variable to a random value from a list or range. The first parameter is the
+          state variable, and the subsequent parameters can be a list of values to randomly choose from
+          OR an integer range. An integer range may be specified by a low bound and a high bound
+          with a hyphen in the middle (ie, 1-10). The range is inclusive, and a random integer within the
+          bounds (inclusive) will be used. Both the list and the range have a uniform distribution.</td>
+      <td><pre class="script">#RANDOM hits, 5-10</pre>
+          <pre class="script">#RANDOM direction, north, south, east, west</pre></td>
+    </tr>
+    <tr>
       <td>REPLACE</td>
       <td>KWARGS</td>
       <td>Replaces a map tile. Uses KWARGs, `target` and attributes prefixed with `target_` can be used to specify which tiles to replace.

--- a/lib/dungeon_crawl_web/templates/page/reference.html.eex
+++ b/lib/dungeon_crawl_web/templates/page/reference.html.eex
@@ -94,7 +94,11 @@
     </tr>
     <tr>
       <td>pulling</td>
-      <td>When this tile is pulled, it will attempt to pull another nearby tile. This defaults to false.</td>
+      <td>When this tile is pulled, it will attempt to pull another nearby tile. This defaults to false. When it is
+          an integer, it will only pull the map tile with id matching this value. When `map_tile_id`, this value will
+          be replaced with the id of the tile it pulls on a pull command or chain pull. If nothing is pulled,
+          then pulling will be set to false. This helps to create double linked chains of map tiles that will only pull
+          one specific tile, and will only be pulled by one specific tile.</td>
     </tr>
   </table>
 

--- a/lib/dungeon_crawl_web/templates/page/reference.html.eex
+++ b/lib/dungeon_crawl_web/templates/page/reference.html.eex
@@ -147,6 +147,19 @@
       <td><pre class="script">@@ALARM = true</pre></td>
     </tr>
     <tr>
+      <td>?&lt;target&gt;@</td>
+      <td>Other's State Value</td>
+      <td>This is for setting state values of another object. There may be instances when the GIVE or TAKE
+          commands are insufficient. The target can be a direction, "sender" (for the event sender if applicable)
+          or the id of the target object. Additionally, {@state_val} can be used to determine the target from
+          a state value of the current object (which should resolve to a direction or object id). Cannot target a
+          player object. Additionally, if the target is invalid (ie, nonexistant, a player, etc), this will act
+          as a noop.</td>
+      <td><pre class="script">?north@locked = true</pre>
+          <pre class="script">?{@facing}@blocking = false</pre>
+          <pre class="script">?12345@health += 10</pre></td>
+    </tr>
+    <tr>
       <td>/</td>
       <td>Shorthand</td>
       <td>Shorthand for the "GO" command. Slash followed by a n, s, e, or w (for north, south east or west).

--- a/lib/dungeon_crawl_web/templates/page/reference.html.eex
+++ b/lib/dungeon_crawl_web/templates/page/reference.html.eex
@@ -154,7 +154,8 @@
           or the id of the target object. Additionally, {@state_val} can be used to determine the target from
           a state value of the current object (which should resolve to a direction or object id). Cannot target a
           player object. Additionally, if the target is invalid (ie, nonexistant, a player, etc), this will act
-          as a noop.</td>
+          as a noop. Its also important to note that this will not trigger any side effects (such as killing and
+          removing an object from the board when its health reaches zero), unlike the TAKE command.</td>
       <td><pre class="script">?north@locked = true</pre>
           <pre class="script">?{@facing}@blocking = false</pre>
           <pre class="script">?12345@health += 10</pre></td>

--- a/lib/dungeon_crawl_web/templates/page/reference.html.eex
+++ b/lib/dungeon_crawl_web/templates/page/reference.html.eex
@@ -143,8 +143,11 @@
     <tr>
       <td>@@</td>
       <td>Dungeon value</td>
-      <td>Similar to the State Value, however this is for the entire dungeon.</td>
-      <td><pre class="script">@@ALARM = true</pre></td>
+      <td>Similar to the State Value, however this is for the entire dungeon. There are a few special dungeon values
+          which are read only and return the boundary row/col: north_edge, west_edge, south_edge, east_edge.
+          This can be useful for objects that need to know when they've reached the edge via a IF command.</td>
+      <td><pre class="script">@@ALARM = true</pre>
+          <pre class="script">#IF @col >= @@east_edge, something</pre></td>
     </tr>
     <tr>
       <td>?&lt;target&gt;@</td>

--- a/lib/dungeon_crawl_web/templates/page/reference.html.eex
+++ b/lib/dungeon_crawl_web/templates/page/reference.html.eex
@@ -222,10 +222,12 @@
       <td>Another map tile. `?sender` refers to the map tile that sent the last message.
           Additionally, `?<direction>@` can be used to refer to a state value for a tile in 
           that direction the map tile/object that sent the last message. Some commands require a
-          tile, and some commands require a value.</td>
+          tile, and some commands require a value. An interpolated direction may come from the map
+          tile's state value by using `?{@<state variable>}@`.</td>
       <td><pre class="script">?sender</pre>
           <pre class="script">?sender@health</pre>
-          <pre class="script">?south@blocking</pre></td>
+          <pre class="script">?south@blocking</pre>
+          <pre class="script">?{@facing}@blocking</pre></td>
     </tr>
     <tr>
       <td>&lt;prefix&gt;&lt;variable&gt;+&lt;string&gt;</td>
@@ -348,7 +350,8 @@
           starting next at the first active matching label (nothing happens if there is no matching active label).</td>
       <td><pre class="script">#IF @open, ALREADY_OPEN</pre>
           <pre class="script">#IF ?sender@blocking, TOUCH</pre>
-          <pre class="script">#IF @timer > 0, CONTINUE</pre></td>
+          <pre class="script">#IF @timer > 0, CONTINUE</pre>
+          <pre class="script">#IF ?{@facing}@blocking, TOUCH</pre></td>
     </tr>
     <tr>
       <td>LOCK</td>

--- a/test/dungeon_crawl/scripting/command_test.exs
+++ b/test/dungeon_crawl/scripting/command_test.exs
@@ -40,6 +40,7 @@ defmodule DungeonCrawl.Scripting.CommandTest do
     assert Command.get_command(:noop) == :noop
     assert Command.get_command(:push) == :push
     assert Command.get_command(:put) == :put
+    assert Command.get_command(:random) == :random
     assert Command.get_command(:replace) == :replace
     assert Command.get_command(:remove) == :remove
     assert Command.get_command(:restore) == :restore
@@ -954,6 +955,25 @@ defmodule DungeonCrawl.Scripting.CommandTest do
 
     %Runner{state: updated_state} = Command.put(%Runner{program: program, object_id: map_tile.id, state: state}, params)
     assert updated_state == state
+  end
+
+  test "RANDOM" do
+    {map_tile, state} = Instances.create_map_tile(%Instances{}, %MapTile{id: 123, row: 1, col: 2, z_index: 0, character: ".", state: ""})
+
+    # range
+    %Runner{state: updated_state} = Command.random(%Runner{object_id: map_tile.id, state: state}, ["cookies", "5 - 10"])
+    updated_map_tile = Instances.get_map_tile_by_id(updated_state, map_tile)
+    assert Enum.member?(5..10, updated_map_tile.parsed_state[:cookies])
+
+    # list of values
+    %Runner{state: updated_state} = Command.random(%Runner{object_id: map_tile.id, state: state}, ["answer", "yes", "no"])
+    updated_map_tile = Instances.get_map_tile_by_id(updated_state, map_tile)
+    assert Enum.member?(["yes", "no"], updated_map_tile.parsed_state[:answer])
+
+    # bad range acts like a value
+    %Runner{state: updated_state} = Command.random(%Runner{object_id: map_tile.id, state: state}, ["flaw", " - 5"])
+    updated_map_tile = Instances.get_map_tile_by_id(updated_state, map_tile)
+    assert Enum.member?(["- 5"], updated_map_tile.parsed_state[:flaw])
   end
 
   test "REPLACE tile in a direction" do

--- a/test/dungeon_crawl/scripting/parser_test.exs
+++ b/test/dungeon_crawl/scripting/parser_test.exs
@@ -85,6 +85,10 @@ defmodule DungeonCrawl.Scripting.ParserTest do
                #PUSH @facing
                #SHIFT clockwise
                #IF ?{@facing}@blocking, TOUCH
+               #IF ?random@10 < 7, TOUCH
+               #MOVE @facing
+               #GO @facing
+               #TRY @facing
                """
       assert {:ok, program = %Program{}} = Parser.parse(script)
       assert program == %Program{instructions: %{1 => [:halt, [""]],
@@ -140,6 +144,10 @@ defmodule DungeonCrawl.Scripting.ParserTest do
                                                  51 => [:push, [{:state_variable, :facing}]],
                                                  52 => [:shift, ["clockwise"]],
                                                  53 => [:jump_if, [{{:state_variable, :facing}, :blocking}, "TOUCH"]],
+                                                 54 => [:jump_if, [[{:random, 1..10}, "<", 7], "TOUCH"]],
+                                                 55 => [:move, [{:state_variable, :facing}]],
+                                                 56 => [:go, [{:state_variable, :facing}]],
+                                                 57 => [:try, [{:state_variable, :facing}]],
                                                  },
                                  status: :alive,
                                  pc: 1,

--- a/test/dungeon_crawl/scripting/parser_test.exs
+++ b/test/dungeon_crawl/scripting/parser_test.exs
@@ -84,6 +84,7 @@ defmodule DungeonCrawl.Scripting.ParserTest do
                #PUSH north, 1
                #PUSH @facing
                #SHIFT clockwise
+               #IF ?{@facing}@blocking, TOUCH
                """
       assert {:ok, program = %Program{}} = Parser.parse(script)
       assert program == %Program{instructions: %{1 => [:halt, [""]],
@@ -138,6 +139,7 @@ defmodule DungeonCrawl.Scripting.ParserTest do
                                                  50 => [:push, ["north", 1]],
                                                  51 => [:push, [{:state_variable, :facing}]],
                                                  52 => [:shift, ["clockwise"]],
+                                                 53 => [:jump_if, [{{:state_variable, :facing}, :blocking}, "TOUCH"]],
                                                  },
                                  status: :alive,
                                  pc: 1,

--- a/test/dungeon_crawl/scripting/program_validator_test.exs
+++ b/test/dungeon_crawl/scripting/program_validator_test.exs
@@ -90,6 +90,8 @@ defmodule DungeonCrawl.Scripting.ProgramValidatorTest do
     #PUSH norf, 3
     #PUSH east, crayon
     #SHIFT neutral
+    #IF ?random@10 < 2, touch
+    #IF ?random@5552 < 2, touch
     """
   end
 
@@ -160,6 +162,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidatorTest do
                "Line 56: PUSH command references invalid direction `norf`",
                "Line 57: PUSH command has invalid range `crayon`",
                "Line 58: SHIFT command references invalid rotation `neutral`",
+               "Line 60: IF command malformed",
               ],
               program} == ProgramValidator.validate(program, user)
       assert {:error,
@@ -204,6 +207,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidatorTest do
                "Line 56: PUSH command references invalid direction `norf`",
                "Line 57: PUSH command has invalid range `crayon`",
                "Line 58: SHIFT command references invalid rotation `neutral`",
+               "Line 60: IF command malformed",
               ],
               program} == ProgramValidator.validate(program, admin)
     end

--- a/test/dungeon_crawl/scripting/variable_resolution_test.exs
+++ b/test/dungeon_crawl/scripting/variable_resolution_test.exs
@@ -11,7 +11,7 @@ defmodule DungeonCrawl.Scripting.VariableResolutionTest do
   describe "resolve_variable" do
     test "resolves state_variable" do
       {map_tile_1, state} = Instances.create_map_tile(%Instances{},
-                              %MapTile{id: 1, row: 1, col: 1, color: "red", background_color: "gray", state: "red_key: 1"})
+                              %MapTile{id: 1, row: 1, col: 1, color: "red", background_color: "gray", state: "red_key: 1, facing: west, point: north"})
       {map_tile_2, state} = Instances.create_map_tile(state,
                               %MapTile{id: 2, row: 0, col: 1, state: "pass: bob", character: "X", name: "two", background_color: "red"})
 
@@ -40,6 +40,15 @@ defmodule DungeonCrawl.Scripting.VariableResolutionTest do
       assert VariableResolution.resolve_variable(runner_state1, {{:direction, "north"}, :character}) == "X"
       assert VariableResolution.resolve_variable(runner_state1, {{:direction, "north"}, :foobar}) == nil
       assert VariableResolution.resolve_variable(runner_state1, {{:direction, "south"}, :character}) == nil
+
+      # can get state variables from a tile in a direction relative to current facing, doesnt break when to tile or no value
+      assert VariableResolution.resolve_variable(runner_state1, {{:direction, "clockwise"}, :character}) == "X"
+      assert VariableResolution.resolve_variable(runner_state1, {{:direction, "clockwise"}, :foobar}) == nil
+
+      # can get state variables from a tile in a direction specified by a state value, doesnt break when to tile or no value
+      assert VariableResolution.resolve_variable(runner_state1, {{:state_variable, :point}, :character}) == "X"
+      assert VariableResolution.resolve_variable(runner_state1, {{:state_variable, :point}, :foobar}) == nil
+      assert VariableResolution.resolve_variable(runner_state1, {{:state_variable, :derp}, :character}) == nil
 
       # can also get an instance_state_value
       assert VariableResolution.resolve_variable(runner_state1, {:instance_state_variable, :flash}) == "fire"

--- a/test/dungeon_crawl/tile_templates/tile_seeder_test.exs
+++ b/test/dungeon_crawl/tile_templates/tile_seeder_test.exs
@@ -55,9 +55,11 @@ defmodule DungeonCrawl.TileTemplates.TileSeederTest do
   end
 
   test "creatures" do
+    assert TileSeeder.bandit
     assert TileSeeder.expanding_foam
     assert TileSeeder.pede_head
     assert TileSeeder.pede_body
+    assert Repo.one(from tt in TileTemplate, where: tt.name == "Bandit")
     assert Repo.one(from tt in TileTemplate, where: tt.name == "Expanding Foam")
     assert Repo.one(from tt in TileTemplate, where: tt.name == "PedeHead")
     assert Repo.one(from tt in TileTemplate, where: tt.name == "PedeBody")
@@ -83,11 +85,11 @@ defmodule DungeonCrawl.TileTemplates.TileSeederTest do
     initial_count = Repo.one(from t in TileTemplate, select: count(t.id))
     TileSeeder.seed_all()
     seeded_count = Repo.one(from t in TileTemplate, select: count(t.id))
-    assert seeded_count - initial_count == 35
+    assert seeded_count - initial_count == 36
 
     # does not add the seeds again
     TileSeeder.seed_all()
     seeded_count2 = Repo.one(from t in TileTemplate, select: count(t.id))
-    assert seeded_count2 - initial_count == 35
+    assert seeded_count2 - initial_count == 36
   end
 end

--- a/test/dungeon_crawl/tile_templates/tile_templates_test.exs
+++ b/test/dungeon_crawl/tile_templates/tile_templates_test.exs
@@ -184,6 +184,46 @@ defmodule DungeonCrawl.TileTemplatesTest do
       assert {:error, %Ecto.Changeset{}} = TileTemplates.find_or_create_tile_template(@invalid_attrs)
     end
 
+    test "update_or_create_tile_template/2" do
+      {:ok, existing_tile_template} = TileTemplates.create_tile_template(@valid_attrs)
+      # finds existing template by slug and updates it
+      assert {:ok, tile_template} = TileTemplates.update_or_create_tile_template("a_big_x", Map.put(@valid_attrs, :character, "Y"))
+      assert tile_template.id == existing_tile_template.id
+      assert tile_template.character == "Y"
+
+      # does not find the slug, but finds a matching tile for the other attrs
+      assert {:ok, tile_template} = TileTemplates.update_or_create_tile_template("a_big_y", Map.put(@valid_attrs, :character, "Y"))
+      assert tile_template.id == existing_tile_template.id
+      assert tile_template.character == "Y"
+      assert tile_template.slug == "a_big_x"
+
+      # creates the unfound tile
+      assert {:ok, tile_template} = TileTemplates.update_or_create_tile_template("not", Map.merge(@valid_attrs, %{character: "Z", name: "Big Z"}))
+      assert tile_template.id != existing_tile_template.id
+      assert tile_template.character == "Z"
+      assert tile_template.slug == "big_z"
+    end
+
+    test "update_or_create_tile_template!/2" do
+      {:ok, existing_tile_template} = TileTemplates.create_tile_template(@valid_attrs)
+      # finds existing template by slug and updates it
+      assert tile_template = TileTemplates.update_or_create_tile_template!("a_big_x", Map.put(@valid_attrs, :character, "Y"))
+      assert tile_template.id == existing_tile_template.id
+      assert tile_template.character == "Y"
+
+      # does not find the slug, but finds a matching tile for the other attrs
+      assert tile_template = TileTemplates.update_or_create_tile_template!("a_big_y", Map.put(@valid_attrs, :character, "Y"))
+      assert tile_template.id == existing_tile_template.id
+      assert tile_template.character == "Y"
+      assert tile_template.slug == "a_big_x"
+
+      # creates the unfound tile
+      assert tile_template = TileTemplates.update_or_create_tile_template!("not", Map.merge(@valid_attrs, %{character: "Z", name: "Big Z"}))
+      assert tile_template.id != existing_tile_template.id
+      assert tile_template.character == "Z"
+      assert tile_template.slug == "big_z"
+    end
+
     test "update_tile_template/2 with valid data updates the tile_template" do
       tile_template = tile_template_fixture()
       assert {:ok, tile_template} = TileTemplates.update_tile_template(tile_template, @update_attrs)


### PR DESCRIPTION
Adds ehancements around state related things:
- Support for interpolating state values for other checks and value assignments/changes, ie `?{@facing}@blocking`
- Adding RANDOM command
- Adding `map_tile_id` as valid value for `pulling`, which becomes the pullee's id when it pulls another tile
- Added CHANGE_OTHER_STATE command (similar to CHANGE_STATE) with shorthand `?<target>@<state attribute>`
- Variable resolver for getting the row/col of the board edges
- Modified seeders to update or create the tile template using the slug to find the previously seeded tile template
- Modifed centipede's to have pullable and pulling link to the segment in front and behind (if applicable)
- Added 'bandit' creature tile template
- JS package bumps from npm audit