### PR TITLE
Program Message Queue

### DIFF
--- a/lib/dungeon_crawl/dungeon_processes/instance_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_process.ex
@@ -336,7 +336,7 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
   defp _message_programs([], program_contexts), do: program_contexts
   defp _message_programs([ {po_id, label, sender} | messages], program_contexts) do
     program_context = program_contexts[po_id]
-    if program_context do # && program_context.program.message == {} do
+    if program_context do
       program = program_context.program
       _message_programs(messages, %{ program_contexts | po_id => %{ program_context | program: Program.send_message(program, label, sender),
                                                                     event_sender: sender}})

--- a/lib/dungeon_crawl/dungeon_processes/instance_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instance_process.ex
@@ -310,8 +310,6 @@ defmodule DungeonCrawl.DungeonProcesses.InstanceProcess do
     # Merge the existing program_contexts with whatever new programs were spawned
     program_contexts = Map.new(program_contexts, fn [k,v] -> {k,v} end)
                        |> Map.merge(Map.take(state.program_contexts, state.new_pids))
-Logger.info "Program messages:"
-Logger.info inspect state.program_messages
     _standard_behaviors(state.program_messages, %{ state | program_contexts: program_contexts })
     |> _message_programs()
   end
@@ -326,10 +324,6 @@ Logger.info inspect state.program_messages
     if runner_state.program.status == :dead do
       { other_program_contexts, updated_state}
     else
-Logger.info "program still alive"
-Logger.info inspect pid
-Logger.info inspect Map.take(runner_state, [:program, :object_id, :event_sender])
-
       {[ [pid, Map.take(runner_state, [:program, :object_id, :event_sender])] | other_program_contexts ], updated_state}
     end
   end
@@ -341,22 +335,12 @@ Logger.info inspect Map.take(runner_state, [:program, :object_id, :event_sender]
   end
   defp _message_programs([], program_contexts), do: program_contexts
   defp _message_programs([ {po_id, label, sender} | messages], program_contexts) do
-Logger.info "message programs"
-Logger.info inspect po_id
     program_context = program_contexts[po_id]
     if program_context do # && program_context.program.message == {} do
-Logger.info "sending message"
-Logger.info inspect po_id
-Logger.info inspect label
-Logger.info inspect sender
       program = program_context.program
       _message_programs(messages, %{ program_contexts | po_id => %{ program_context | program: Program.send_message(program, label, sender),
                                                                     event_sender: sender}})
     else
-Logger.info "no context or already had message"
-Logger.info inspect po_id
-Logger.info inspect program_context
-#Logger.info inspect program_context && program_context.program.messages
       _message_programs(messages, program_contexts)
     end
   end

--- a/lib/dungeon_crawl/dungeon_processes/instances.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instances.ex
@@ -232,10 +232,11 @@ defmodule DungeonCrawl.DungeonProcesses.Instances do
                                            end
                             messages = program.messages
                                        |> Enum.map(fn({label, sender} = message) ->
-                                            if sender && sender.map_tile_id == old_temp_id do
-                                              {label, %{sender | map_tile_id: new_id}}
-                                            else
-                                              message
+                                            case sender do
+                                              %{map_tile_id: map_tile_id} when map_tile_id == old_temp_id ->
+                                                {label, %{sender | map_tile_id: new_id}}
+                                              _ ->
+                                                message
                                             end
                                           end)
                             {pid, %{program_context | event_sender: event_sender, program: %{ program | messages: messages}}}

--- a/lib/dungeon_crawl/dungeon_processes/instances.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instances.ex
@@ -216,8 +216,12 @@ defmodule DungeonCrawl.DungeonProcesses.Instances do
     z_indexes = state.map_by_coords[{map_tile.row, map_tile.col}]
                 |> Map.put(map_tile.z_index, new_id)
     by_coords = Map.put(state.map_by_coords, {map_tile.row, map_tile.col}, z_indexes)
-    program_contexts = Map.put(state.program_contexts, new_id, %{ state.program_contexts[old_temp_id] | object_id: new_id} )
-                       |> Map.delete(old_temp_id)
+    program_contexts = if state.program_contexts[old_temp_id] do
+                         Map.put(state.program_contexts, new_id, %{ state.program_contexts[old_temp_id] | object_id: new_id} )
+                         |> Map.delete(old_temp_id)
+                       else
+                         state.program_contexts
+                       end
 
     %{ state | map_by_ids: by_ids, map_by_coords: by_coords, program_contexts: program_contexts }
   end

--- a/lib/dungeon_crawl/dungeon_processes/instances.ex
+++ b/lib/dungeon_crawl/dungeon_processes/instances.ex
@@ -222,6 +222,25 @@ defmodule DungeonCrawl.DungeonProcesses.Instances do
                        else
                          state.program_contexts
                        end
+    program_contexts = program_contexts
+                       |> Map.to_list
+                       |> Enum.map(fn({pid, %{event_sender: event_sender, program: program} = program_context}) ->
+                            event_sender = if event_sender && event_sender.map_tile_id == old_temp_id do
+                                             %{ event_sender | map_tile_id: new_id}
+                                           else
+                                             event_sender
+                                           end
+                            messages = program.messages
+                                       |> Enum.map(fn({label, sender} = message) ->
+                                            if sender && sender.map_tile_id == old_temp_id do
+                                              {label, %{sender | map_tile_id: new_id}}
+                                            else
+                                              message
+                                            end
+                                          end)
+                            {pid, %{program_context | event_sender: event_sender, program: %{ program | messages: messages}}}
+                          end)
+                       |> Enum.into(%{})
 
     %{ state | map_by_ids: by_ids, map_by_coords: by_coords, program_contexts: program_contexts }
   end

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -1202,11 +1202,6 @@ defmodule DungeonCrawl.Scripting.Command do
 
   defp _send_message_via_ids(runner_state, _label, []), do: runner_state
   defp _send_message_via_ids(%Runner{state: state, object_id: object_id} = runner_state, label, [po_id | program_object_ids]) do
-Logger.info "Sending message via ids:"
-Logger.info inspect po_id
-Logger.info inspect label
-Logger.info "sender:"
-Logger.info inspect object_id
     object = Instances.get_map_tile_by_id(state, %{id: object_id})
     _send_message_via_ids(
       %{ runner_state | state: %{ state | program_messages: [ {po_id, label, %{map_tile_id: object_id, parsed_state: object.parsed_state}} |

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -665,8 +665,7 @@ defmodule DungeonCrawl.Scripting.Command do
                                   else: %{map_tile_id: nil, parsed_state: %{}}
         program = %{program | status: :wait, wait_cycles: wait_cycles}
         %{ runner_state |
-             program: program,
-             state: %{ state | program_messages: [ {object_id, "THUD", sender} | state.program_messages] } }
+             program: Program.send_message(program, "THUD", sender) }
 
       retryable ->
           %{ runner_state | program: %{program | pc: program.pc - 1, status: :wait, wait_cycles: wait_cycles} }
@@ -684,8 +683,7 @@ defmodule DungeonCrawl.Scripting.Command do
                                   else: %{map_tile_id: nil, parsed_state: %{}}
         program = %{program | status: :wait, wait_cycles: wait_cycles}
         %{ runner_state |
-             program: program,
-             state: %{ state | program_messages: [ {object_id, "THUD", sender} | state.program_messages] } }
+             program: Program.send_message(program, "THUD", sender) }
 
       retryable ->
           %{ runner_state | program: %{program | pc: program.pc - 1, status: :wait, wait_cycles: wait_cycles} }

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -660,23 +660,14 @@ defmodule DungeonCrawl.Scripting.Command do
     object = Instances.get_map_tile_by_id(state, %{id: object_id})
     wait_cycles = StateValue.get_int(object, :wait_cycles, 5)
     cond do
-      line_number = Program.line_for(program, "THUD") ->
-Logger.info "THUD! got by obj id:"
-Logger.info inspect object_id
-          sender = if blocking_obj, do: %{map_tile_id: blocking_obj.id, parsed_state: blocking_obj.parsed_state},
-                                    else: %{map_tile_id: nil, parsed_state: %{}}
-Logger.info "blocker/sender:"
-Logger.info inspect sender
-          program = %{program | pc: line_number, lc: 0, status: :wait, wait_cycles: wait_cycles}
-#          program_context = %{ state.program_contexts[object_id] | program: program, event_sender: sender }
-#          state = %{ state | program_contexts: %{ state.program_contexts | object_id => program_context } }
+      Program.line_for(program, "THUD") ->
+        sender = if blocking_obj, do: %{map_tile_id: blocking_obj.id, parsed_state: blocking_obj.parsed_state},
+                                  else: %{map_tile_id: nil, parsed_state: %{}}
+        program = %{program | status: :wait, wait_cycles: wait_cycles}
+        %{ runner_state |
+             program: program,
+             state: %{ state | program_messages: [ {object_id, "THUD", sender} | state.program_messages] } }
 
-
-          %{ runner_state |
-               program: program,
-               state: %{ state | program_messages: [ {object_id, "THUD", sender} | state.program_messages] } }
-
-#          %{ runner_state | state: state, program: program }
       retryable ->
           %{ runner_state | program: %{program | pc: program.pc - 1, status: :wait, wait_cycles: wait_cycles} }
       true ->
@@ -688,22 +679,14 @@ Logger.info inspect sender
     object = Instances.get_map_tile_by_id(state, %{id: object_id})
     wait_cycles = StateValue.get_int(object, :wait_cycles, 5)
     cond do
-      line_number = Program.line_for(program, "THUD") ->
-Logger.info "THUD! got by obj id:"
-Logger.info inspect object_id
-          sender = if blocking_obj, do: %{map_tile_id: blocking_obj.id, parsed_state: blocking_obj.parsed_state},
-                                    else: %{map_tile_id: nil, parsed_state: %{}}
-Logger.info "blocker/sender:"
-Logger.info inspect sender
-          program = %{program | pc: line_number, status: :wait, wait_cycles: wait_cycles}
-#          program_context = %{ state.program_contexts[object_id] | program: program, event_sender: sender }
-#          state = %{ state | program_contexts: %{ state.program_contexts | object_id => program_context } }
+      Program.line_for(program, "THUD") ->
+        sender = if blocking_obj, do: %{map_tile_id: blocking_obj.id, parsed_state: blocking_obj.parsed_state},
+                                  else: %{map_tile_id: nil, parsed_state: %{}}
+        program = %{program | status: :wait, wait_cycles: wait_cycles}
+        %{ runner_state |
+             program: program,
+             state: %{ state | program_messages: [ {object_id, "THUD", sender} | state.program_messages] } }
 
-          %{ runner_state |
-               program: program,
-               state: %{ state | program_messages: [ {object_id, "THUD", sender} | state.program_messages] } }
-
-#          %{ runner_state | state: state, program: program }
       retryable ->
           %{ runner_state | program: %{program | pc: program.pc - 1, status: :wait, wait_cycles: wait_cycles} }
       true ->

--- a/lib/dungeon_crawl/scripting/program.ex
+++ b/lib/dungeon_crawl/scripting/program.ex
@@ -34,10 +34,5 @@ defmodule DungeonCrawl.Scripting.Program do
     # TODO: Probably want to have the programs be their own separate processes eventually.
     messages = Enum.reverse([{label, sender} | Enum.reverse(program.messages) ])
     %{ program | messages: messages }
-#    if program.message == {} do
-#      %{ program | message: {label, sender} }
-#    else
-#      program
-#    end
   end
 end

--- a/lib/dungeon_crawl/scripting/program.ex
+++ b/lib/dungeon_crawl/scripting/program.ex
@@ -2,7 +2,7 @@ defmodule DungeonCrawl.Scripting.Program do
   @doc """
   A struct containing the representation of a program and its state.
   """
-  defstruct status: :dead, pc: 1, lc: 0, instructions: %{}, labels: %{}, locked: false, broadcasts: [], responses: [], wait_cycles: 0, message: {}
+  defstruct status: :dead, pc: 1, lc: 0, instructions: %{}, labels: %{}, locked: false, broadcasts: [], responses: [], wait_cycles: 0, messages: []
 
   @doc """
   Returns the line number for the given active label for the program.
@@ -32,10 +32,12 @@ defmodule DungeonCrawl.Scripting.Program do
   """
   def send_message(program, label, sender \\ nil) do
     # TODO: Probably want to have the programs be their own separate processes eventually.
-    if program.message == {} do
-      %{ program | message: {label, sender} }
-    else
-      program
-    end
+    messages = Enum.reverse([{label, sender} | Enum.reverse(program.messages) ])
+    %{ program | messages: messages }
+#    if program.message == {} do
+#      %{ program | message: {label, sender} }
+#    else
+#      program
+#    end
   end
 end

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -28,7 +28,7 @@ require Logger
   end
 
   def run(%Runner{program: program, object_id: object_id, state: state} = runner_state) do
-    if program.messages == [] || program.status == "alive" || program.status == "dead" do
+    if program.messages == [] || program.status == :alive || program.status == :dead do
       # todo: maybe have the check for active tile live elsewhere
       if Instances.get_map_tile_by_id(state, %{id: object_id}) do
         _run(runner_state)
@@ -64,7 +64,7 @@ end
         # increment program counter, check for end of program
         program = %{runner_state.program | pc: runner_state.program.pc + 1}
         if program.pc > Enum.count(program.instructions) do
-          %{ runner_state | program: %{program | pc: 0, status: :idle} }
+          run( %{ runner_state | program: %{program | pc: 0, status: :idle} } )
         else
           run( %{ runner_state | program: program } )
         end

--- a/lib/dungeon_crawl/tile_templates/tile_seeder/basic_tiles.ex
+++ b/lib/dungeon_crawl/tile_templates/tile_seeder/basic_tiles.ex
@@ -82,7 +82,7 @@ defmodule DungeonCrawl.TileTemplates.TileSeeder.BasicTiles do
         script: """
                 #WALK @facing
                 :THUD
-                #SEND shot, @facing
+                #SEND shot, ?sender
                 #DIE
                 :TOUCH
                 #SEND shot, ?sender

--- a/lib/dungeon_crawl_web/templates/page/reference.html.eex
+++ b/lib/dungeon_crawl_web/templates/page/reference.html.eex
@@ -108,13 +108,17 @@
   <p>A script can be defined which will control additional behavior of the map tile beyond the basic
      built in state values. A script begins running commands starting at the top, and working its way down.
      Certain commands, such as movement, will pause the script for a noticable amount of time (determined by
-     the "wait_cycles"). When a map tile receives a message it can react, the program will jump and start
+     the "wait_cycles"). When a map tile receives a message it can react to, the program will jump and start
      executing instructions from that point. A message will be reacted to if it is one of the standard behaviors,
      or if the map tile has a matching label in its script.</p>
 
   <p>The script will continue to run until there are no more instructions it can run, or it encounters the END or
      TERMINATE instruction. For the former two, the script will be idle, and will no nothing further unless it receives
-     a message to which it is able to respond.</p>
+     a message to which it is able to respond. A script may recieve messages that will be queued in the order they were
+     recieved. When running the script, when its status becomes `idle` or `waiting`, if there are messages, the top one
+     will change the program counter and jump execution to that if that label exists and is active
+     (also changing the status to `alive`), otherwise the next message will be handled. When there are no more messages for
+     that program, and the program status is `idle` or `waiting`, then the next program will be run.</p>
 
   <p>One instruction per line. Each line may have a prefix, denoting what that line is.</p>
 

--- a/test/dungeon_crawl/dungeon_processes/instances_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/instances_test.exs
@@ -205,7 +205,9 @@ defmodule DungeonCrawl.DungeonProcesses.InstancesTest do
     map_tile = %{id: 1000, row: 3, col: 4, z_index: 0, character: "M", state: "", script: "#END"}
     {_map_tile, state} = Instances.create_map_tile(%Instances{}, map_tile)
     program_contexts = %{ 1000 => %{ program: %{state.program_contexts[1000].program |
-                                                 messages: [{"touch", %{map_tile_id: "new_0"}}, {"touch", nil}]},
+                                                 messages: [{"touch", %{map_tile_id: "new_0"}},
+                                                            {"touch", nil},
+                                                            {"touch", Map.merge(%Location{}, %{parsed_state: {}} )}]},
                                      event_sender: %{map_tile_id: "new_0"} }}
     state = %{ state | program_contexts: program_contexts }
 
@@ -226,7 +228,9 @@ defmodule DungeonCrawl.DungeonProcesses.InstancesTest do
     assert %{1 => %{object_id: 1}} = updated_state.program_contexts
     refute updated_state.program_contexts[new_map_tile.id]
 
-    assert updated_state.program_contexts[1000].program.messages == [{"touch", %{map_tile_id: 1}}, {"touch", nil}]
+    assert updated_state.program_contexts[1000].program.messages == [{"touch", %{map_tile_id: 1}},
+                                                                     {"touch", nil},
+                                                                     {"touch", Map.merge(%Location{}, %{parsed_state: {}})}]
     assert updated_state.program_contexts[1000].event_sender == %{map_tile_id: 1}
   end
 

--- a/test/dungeon_crawl/scripting/program_test.exs
+++ b/test/dungeon_crawl/scripting/program_test.exs
@@ -23,9 +23,10 @@ defmodule DungeonCrawl.Scripting.ProgramTest do
 
   test "send_message/2" do
     program = Program.send_message(%Program{}, "touch", 1234)
-    assert {"touch", 1234} == program.message
+    assert [{"touch", 1234}] == program.messages
 
+    # adds messages to the end of the list, FIFO
     program = Program.send_message(program, "panic")
-    assert {"touch", 1234} == program.message
+    assert [{"touch", 1234}, {"panic", nil}] == program.messages
   end
 end

--- a/test/dungeon_crawl/scripting/runner_test.exs
+++ b/test/dungeon_crawl/scripting/runner_test.exs
@@ -50,14 +50,15 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       stubbed_object = %{id: 1, state: "", parsed_state: %{}}
       stubbed_state = %Instances{map_by_ids: %{ 1 => stubbed_object} }
 
-      %Runner{program: run_program} = Runner.run(%Runner{program: %{program | message: {"there", nil}}, object_id: 1, state: stubbed_state})
+      %Runner{program: run_program} = Runner.run(%Runner{program: %{program | messages: [{"there", nil}], status: :idle}, object_id: 1, state: stubbed_state})
       assert run_program.responses == [{"message", %{message: "Last text"}}]
-      assert run_program.message == {}
+      assert run_program.messages == []
 
-      # A label passed in overrides the existing message
-      %Runner{program: run_program} = Runner.run(%Runner{program: %{program | message: {"there", nil}}, object_id: 1, state: stubbed_state}, "here")
-      assert run_program.responses == [{"message", %{message: "After label"}}]
-      assert run_program.message == {}
+      # A label passed in runs from there if possible, then runs queued messages when idle/waiting
+      # And runs messages in order sent (oldest first)
+      %Runner{program: run_program} = Runner.run(%Runner{program: %{program | messages: [{"there", nil}, {"there", nil}]}, object_id: 1, state: stubbed_state}, "here")
+      assert run_program.messages == []
+      assert run_program.responses == [{"message", %{message: "Last text"}}, {"message", %{message: "Last text"}}, {"message", %{message: "After label"}}]
     end
 
     test "when given a label but the label is inactive it does not executes from that" do

--- a/test/dungeon_crawl_web/channels/dungeon_channel_test.exs
+++ b/test/dungeon_crawl_web/channels/dungeon_channel_test.exs
@@ -181,12 +181,6 @@ defmodule DungeonCrawl.DungeonChannelTest do
     refute_broadcast "tile_changes", _anything_really
   end
 
-  @tag up_tile: "#"
-  test "shoot into a blocking or shootable space spawns no bullet but sends the shot message", %{socket: socket} do
-    push socket, "shoot", %{"direction" => "up"}
-    refute_broadcast "tile_changes", _anything_really
-  end
-
   # TODO: refactor the underlying model/channel methods into more testable concerns
   @tag up_tile: "+"
   test "use_door with a valid actions", %{socket: socket, player_location: player_location, basic_tiles: basic_tiles} do


### PR DESCRIPTION
This is an attempt to make program message handling more reliable, without splitting all the programs into their own processes (and instead continuing to build on the instance process module that handles running of scripts and maintaining dungeon board state).

Adds:
- Message queuing for programs; programs will queue messages in the order they are recieved. While running the program, when it goes idle or waiting, it will get the next message in the queue and either start running instructions from there (when there is an active label), or do nothing and work the next message. Once the messaeg queue is clear, then the next program will run.
- Changes the bullet from sending "SHOT" to the facing direction when it recieves the thud message, to sending the "SHOT" message to teh tile that sent the "THUD" message