### PR TITLE
Rename dungeon process supervisor and move to dungeon process

### DIFF
--- a/lib/dungeon_crawl/application.ex
+++ b/lib/dungeon_crawl/application.ex
@@ -17,7 +17,6 @@ defmodule DungeonCrawl.Application do
       # Start your own worker by calling: DungeonCrawlWeb.Worker.start_link(arg1, arg2, arg3)
       # worker(DungeonCrawlWeb.Worker, [arg1, arg2, arg3]),
       {DungeonCrawl.DungeonProcesses.DungeonRegistry, name: DungeonInstanceRegistry},
-      {DynamicSupervisor, name: DungeonCrawl.DungeonProcesses.Supervisor, strategy: :one_for_one},
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/dungeon_crawl/scripting/maths.ex
+++ b/lib/dungeon_crawl/scripting/maths.ex
@@ -76,10 +76,10 @@ defmodule DungeonCrawl.Scripting.Maths do
   """
   def check("!", a, op, :truthy), do: !check(a, op, :truthy)
   def check(_, a, op, :truthy), do: check(a, op, :truthy)
-  def check(a, "==", :truthy), do: !!a
-  def check(a, "!=", :truthy), do: !check(a, "==", :truthy)
   def check("!", a, op, b), do: !check(a, op, b)
   def check(_, a, op, b),   do: check(a, op, b)
+  def check(a, "==", :truthy), do: !!a
+  def check(a, "!=", :truthy), do: !check(a, "==", :truthy)
   def check(a, "!=", b),    do: a != b
   def check(a, "==", b),    do: a == b
   def check(a, "<=", b) when is_number(a) and is_number(b), do: a <= b


### PR DESCRIPTION
The DynamicSupervisor "DungeonProcess.Supervisor" has been moved to being started once for the whole app to being started per LevelRegistry. This supervisor's name was also misleading, since it supervised Level processes and not Dungeon processes (this is cleanup from a previous refactor/renaming).

LevelRegistry 
- modifies internal state to be a struct since there are now several things it relies on knowing (using a tuple was becoming cumbersome)
- Starts a DynamicSupervisor on init to supervise the levels specific to this LevelRegistry process (which is a child of a DungeonProcess)

Maths
- fixing a function definition ordering warning