### PR TITLE
Adding timed messages

### DIFF
--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -142,12 +142,12 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
   Send an event to a tile/program, or all running programs when no tile_id is given.
   If a tile_id is given, the sender must be a player.
   """
-  def send_event(instance, event, sender) do
-    GenServer.cast(instance, {:send_event, {event, sender}})
+  def send_event(instance, event, sender, delay) do
+    GenServer.cast(instance, {:send_event, {event, sender, delay}})
   end
 
-  def send_event(instance, tile_id, event, sender) do
-    GenServer.cast(instance, {:send_event, {tile_id, event, sender}})
+  def send_event(instance, tile_id, event, sender, delay) do
+    GenServer.cast(instance, {:send_event, {tile_id, event, sender, delay}})
   end
 
   @doc """
@@ -334,15 +334,15 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
   end
 
   @impl true
-  def handle_cast({:send_event, {event, sender}}, %Levels{} = state) do
+  def handle_cast({:send_event, {event, sender, delay}}, %Levels{} = state) do
     state = state.program_contexts
-            |> Enum.reduce(state, fn({po_id, _}, state) -> Levels.send_event(state, po_id, event, sender) end)
+            |> Enum.reduce(state, fn({po_id, _}, state) -> Levels.send_event(state, po_id, event, sender, delay) end)
     {:noreply, state}
   end
 
   @impl true
-  def handle_cast({:send_event, {tile_id, event, %DungeonCrawl.Player.Location{} = sender}}, %Levels{} = state) do
-    state = Levels.send_event(state, %{id: tile_id}, event, sender)
+  def handle_cast({:send_event, {tile_id, event, %DungeonCrawl.Player.Location{} = sender, delay}}, %Levels{} = state) do
+    state = Levels.send_event(state, %{id: tile_id}, event, sender, delay)
     {:noreply, state}
   end
 
@@ -568,13 +568,18 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
                        |> _message_programs(state.program_contexts)
     %{state | program_contexts: program_contexts, program_messages: []}
   end
-  defp _message_programs([], program_contexts), do: program_contexts
-  defp _message_programs([ {po_id, label, sender} | messages], program_contexts) do
+  defp _message_programs([], program_contexts),
+       do: program_contexts
+  defp _message_programs([ {po_id, label, sender} | messages], program_contexts),
+       do: _message_programs(po_id, label, sender, 0, messages, program_contexts)
+  defp _message_programs([ {po_id, label, sender, delay} | messages], program_contexts),
+       do: _message_programs(po_id, label, sender, delay, messages, program_contexts)
+  defp _message_programs(po_id, label, sender, delay, messages, program_contexts) do
     program_context = program_contexts[po_id]
     if program_context do
       program = program_context.program
-      _message_programs(messages, %{ program_contexts | po_id => %{ program_context | program: Program.send_message(program, label, sender),
-                                                                    event_sender: sender}})
+      _message_programs(messages, %{ program_contexts | po_id => %{ program_context | program: Program.send_message(program, label, sender, delay),
+        event_sender: sender}})
     else
       _message_programs(messages, program_contexts)
     end

--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -610,6 +610,9 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
         _standard_behaviors(messages, state)
     end
   end
+  defp _standard_behaviors([ _delayed_message | messages ], state) do
+    _standard_behaviors(messages, state)
+  end
 
   defp _destroyable_behavior([ {tile_id, _label, sender} | messages ], state) do
     object = Levels.get_tile_by_id(state, %{id: tile_id})

--- a/lib/dungeon_crawl/dungeon_processes/levels.ex
+++ b/lib/dungeon_crawl/dungeon_processes/levels.ex
@@ -126,7 +126,7 @@ defmodule DungeonCrawl.DungeonProcesses.Levels do
   Send an event to a tile/program.
   Returns the updated state.
   """
-  def send_event(%Levels{program_contexts: program_contexts} = state, %{id: tile_id}, event, %DungeonCrawl.Player.Location{} = sender) do
+  def send_event(%Levels{program_contexts: program_contexts} = state, %{id: tile_id}, event, %DungeonCrawl.Player.Location{} = sender, _) do
     case program_contexts do
       %{^tile_id => %{program: program, object_id: object_id}} ->
         sender = Map.drop(sender, [:tile, :inserted_at, :updated_at, :__meta__]) # the struct is still used elsewhere
@@ -147,8 +147,8 @@ defmodule DungeonCrawl.DungeonProcesses.Levels do
         state
     end
   end
-  def send_event(%Levels{program_messages: program_messages} = state, tile_id, event, %{} = sender) do
-    %{ state | program_messages: [ {tile_id, event, sender} | program_messages] }
+  def send_event(%Levels{program_messages: program_messages} = state, tile_id, event, %{} = sender, delay) do
+    %{ state | program_messages: [ {tile_id, event, sender, delay} | program_messages] }
   end
 
   @doc """

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -833,7 +833,7 @@ defmodule DungeonCrawl.Scripting.Command do
                                   else: %{tile_id: nil, parsed_state: %{}}
         program = %{program | status: :wait, wait_cycles: wait_cycles}
         %{ runner_state |
-             program: Program.send_message(program, "THUD", sender) }
+             program: Program.send_message(program, "THUD", sender, 0) }
 
       retryable ->
           %{ runner_state | program: %{program | pc: program.pc - 1, status: :wait, wait_cycles: wait_cycles} }
@@ -851,7 +851,7 @@ defmodule DungeonCrawl.Scripting.Command do
                                   else: %{tile_id: nil, parsed_state: %{}}
         program = %{program | status: :wait, wait_cycles: wait_cycles}
         %{ runner_state |
-             program: Program.send_message(program, "THUD", sender) }
+             program: Program.send_message(program, "THUD", sender, 0) }
 
       retryable ->
           %{ runner_state | program: %{program | pc: program.pc - 1, status: :wait, wait_cycles: wait_cycles} }
@@ -1323,84 +1323,105 @@ defmodule DungeonCrawl.Scripting.Command do
   The specail varialble `?sender` can be used to send the message to the program
   that sent the event.
   """
-  def send_message(%Runner{} = runner_state, [label]), do: _send_message(runner_state, [label, "self"])
-  def send_message(%Runner{object_id: object_id, state: state} = runner_state, [label, {:state_variable, var}]) do
+  def send_message(%Runner{} = runner_state, [label]), do: send_message(runner_state, [label, "self", 0])
+  def send_message(%Runner{} = runner_state, [label, target]), do: send_message(runner_state, [label, target, 0])
+  def send_message(%Runner{object_id: object_id, state: state} = runner_state, [label, {:state_variable, var}, delay]) do
     object = Levels.get_tile_by_id(state, %{id: object_id})
-    _send_message(runner_state, [label, object.parsed_state[var]])
+    _send_message(runner_state, [label, object.parsed_state[var], delay])
   end
-  def send_message(%Runner{event_sender: event_sender} = runner_state, [label, [:event_sender]]) do
+  def send_message(%Runner{event_sender: event_sender} = runner_state, [label, [:event_sender], delay]) do
     case event_sender do
-      %{tile_id: id} -> _send_message_via_ids(runner_state, label, [id]) # basic tile
-      %{tile_instance_id: id} -> _send_message_via_ids(runner_state, label, [id]) # player tile
+      %{tile_id: id} -> _send_message_via_ids(runner_state, label, delay, [id]) # basic tile
+      %{tile_instance_id: id} -> _send_message_via_ids(runner_state, label, delay, [id]) # player tile
       # Right now, if the actor was a player, this does nothing. Might change later.
       _                  -> runner_state
     end
   end
-  def send_message(%Runner{object_id: object_id, state: state} = runner_state, [label, "global"]) do
+  def send_message(%Runner{} = runner_state, [label, target, delay]) do
+    target = if is_binary(target), do: String.downcase(target), else: target
+    _send_message(runner_state, [label, target, delay])
+  end
+
+  defp _send_message(%Runner{object_id: object_id, state: state} = runner_state, [label, "global", delay]) do
     object = Levels.get_tile_by_id(state, %{id: object_id})
     sender = %{tile_id: nil, parsed_state: Map.put(object.parsed_state, :global_sender, true), name: object.name}
 
     {:ok, dungeon_instance_registry} = Registrar.instance_registry(state.dungeon_instance_id)
     LevelRegistry.flat_list(dungeon_instance_registry)
-    |> Enum.each(fn {_, pid} -> Logger.info("Pew" <> inspect(pid)) && LevelProcess.send_event(pid, label, sender) end)
+    |> Enum.each(fn {_, pid} -> LevelProcess.send_event(pid, label, sender, delay) end)
 
     runner_state
   end
-  def send_message(%Runner{} = runner_state, [label, target]) do
-    target = if is_binary(target), do: String.downcase(target), else: target
-    _send_message(runner_state, [label, target])
-  end
-  defp _send_message(%Runner{state: state, object_id: object_id} = runner_state, [label, "self"]) do
+  defp _send_message(%Runner{state: state, object_id: object_id} = runner_state, [label, "self", 0]) do
     object = Levels.get_tile_by_id(state, %{id: object_id})
     %{ runner_state | state: %{ state | program_messages: [ {object.id, label, %{tile_id: object.id, parsed_state: object.parsed_state}} |
                                                             state.program_messages] } }
   end
-  defp _send_message(%Runner{state: state, object_id: object_id} = runner_state, [label, "others"]) do
+  defp _send_message(%Runner{state: state, program: program, object_id: object_id} = runner_state, [label, "self", delay]) do
+    trigger_time = Time.utc_now |> Time.add(delay, :second)
     object = Levels.get_tile_by_id(state, %{id: object_id})
-    _send_message_id_filter(runner_state, label, fn object_id -> object_id != object.id end)
+    %{ runner_state | program:
+      %{ program | timed_messages: [{trigger_time, label, %{tile_id: object.id, parsed_state: object.parsed_state}} | program.timed_messages] }
+    }
   end
-  defp _send_message(%Runner{} = runner_state, [label, "all"]) do
-    _send_message_id_filter(runner_state, label, fn _object_id -> true end)
+  defp _send_message(%Runner{state: state, object_id: object_id} = runner_state, [label, "others", delay]) do
+    object = Levels.get_tile_by_id(state, %{id: object_id})
+    _send_message_id_filter(runner_state, label, delay, fn object_id -> object_id != object.id end)
   end
-  defp _send_message(%Runner{} = runner_state, [label, target]) when target == "here" do
-    _send_message_in_direction(runner_state, label, target)
+  defp _send_message(%Runner{} = runner_state, [label, "all", delay]) do
+    _send_message_id_filter(runner_state, label, delay, fn _object_id -> true end)
   end
-  defp _send_message(%Runner{} = runner_state, [label, target]) when is_valid_orthogonal(target) do
-    _send_message_in_direction(runner_state, label, target)
+  defp _send_message(%Runner{} = runner_state, [label, target, delay]) when target == "here" do
+    _send_message_in_direction(runner_state, label, target, delay)
   end
-  defp _send_message(%Runner{state: state} = runner_state, [label, target]) do
+  defp _send_message(%Runner{} = runner_state, [label, target, delay]) when is_valid_orthogonal(target) do
+    _send_message_in_direction(runner_state, label, target, delay)
+  end
+  defp _send_message(%Runner{state: state} = runner_state, [label, target, delay]) do
     if is_integer(target) || is_binary(target) && String.starts_with?(target, "new") do
-      _send_message_via_ids(runner_state, label, [target])
+      _send_message_via_ids(runner_state, label, delay, [target])
     else
       tile_ids = state.map_by_ids
                  |> Map.to_list
                  |> Enum.filter(fn {_id, tile} -> String.downcase(tile.name || "") == target end)
                  |> Enum.map(fn {id, _tile} -> id end)
-      _send_message_via_ids(runner_state, label, tile_ids)
+      _send_message_via_ids(runner_state, label, delay, tile_ids)
     end
   end
 
-  defp _send_message_in_direction(%Runner{state: state, object_id: object_id} = runner_state, label, direction) do
+  defp _send_message_in_direction(%Runner{state: state, object_id: object_id} = runner_state, label, direction, delay) do
     object = Levels.get_tile_by_id(state, %{id: object_id})
     tile_ids = Levels.get_tiles(state, object, direction)
                |> Enum.map(&(&1.id))
-    _send_message_via_ids(runner_state, label, tile_ids)
+    _send_message_via_ids(runner_state, label, delay, tile_ids)
   end
 
-  defp _send_message_id_filter(%Runner{state: state} = runner_state, label, filter) do
+  defp _send_message_id_filter(%Runner{state: state} = runner_state, label, delay, filter) do
     program_object_ids = state.program_contexts
                          |> Map.keys()
                          |> Enum.filter(&filter.(&1))
-    _send_message_via_ids(runner_state, label, program_object_ids)
+    _send_message_via_ids(runner_state, label, delay, program_object_ids)
   end
 
-  defp _send_message_via_ids(runner_state, _label, []), do: runner_state
-  defp _send_message_via_ids(%Runner{state: state, object_id: object_id} = runner_state, label, [po_id | program_object_ids]) do
+  defp _send_message_via_ids(runner_state, _label, _, []), do: runner_state
+  defp _send_message_via_ids(%Runner{state: state, object_id: object_id} = runner_state, label, 0, [po_id | program_object_ids]) do
     object = Levels.get_tile_by_id(state, %{id: object_id})
     _send_message_via_ids(
       %{ runner_state | state: %{ state | program_messages: [ {po_id, label, %{tile_id: object_id, parsed_state: object.parsed_state, name: object.name}} |
                                                               state.program_messages] } },
       label,
+      0,
+      program_object_ids
+    )
+  end
+  defp _send_message_via_ids(%Runner{state: state, object_id: object_id} = runner_state, label, delay, [po_id | program_object_ids]) do
+    # TODO: IMplement this
+    object = Levels.get_tile_by_id(state, %{id: object_id})
+    _send_message_via_ids(
+      %{ runner_state | state: %{ state | program_messages: [ {po_id, label, %{tile_id: object_id, parsed_state: object.parsed_state, name: object.name}, delay} |
+                                                              state.program_messages] } },
+      label,
+      delay,
       program_object_ids
     )
   end

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -1417,11 +1417,14 @@ defmodule DungeonCrawl.Scripting.Command do
     )
   end
   defp _send_message_via_ids(%Runner{state: state, object_id: object_id} = runner_state, label, delay, [po_id | program_object_ids]) do
-    # TODO: IMplement this
     object = Levels.get_tile_by_id(state, %{id: object_id})
     _send_message_via_ids(
-      %{ runner_state | state: %{ state | program_messages: [ {po_id, label, %{tile_id: object_id, parsed_state: object.parsed_state, name: object.name}, delay} |
-                                                              state.program_messages] } },
+      %{ runner_state | state: %{ state |
+        program_messages: Enum.reverse([
+          {po_id, label, %{tile_id: object_id, parsed_state: object.parsed_state, name: object.name}, delay}
+          | Enum.reverse(state.program_messages)
+        ])}
+      },
       label,
       delay,
       program_object_ids

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -1302,6 +1302,8 @@ defmodule DungeonCrawl.Scripting.Command do
   Sends a message. A message can be sent to the current running program, or to another program.
   The first parameter is the message to send, and the second (optional) param is the target.
   Both the label and the name are case insensitive.
+  The third (optional) param is the delay in seconds from when the command runs to actually
+  trigger the event.
 
   Valid targets are:
 

--- a/lib/dungeon_crawl/scripting/program.ex
+++ b/lib/dungeon_crawl/scripting/program.ex
@@ -26,7 +26,7 @@ defmodule DungeonCrawl.Scripting.Program do
     iex> Program.line_for(%Program{}, "Fake")
     nil
   """
-  def line_for(program, label) do
+  def line_for(program, label) when is_binary(label) do
     with normalized_label <- String.downcase(label),
          labels when not is_nil(labels) <- program.labels[normalized_label],
          [[line_number, _]] <- labels |> Enum.filter(fn([_l,a]) -> a end) |> Enum.take(1) do
@@ -35,6 +35,7 @@ defmodule DungeonCrawl.Scripting.Program do
       _ -> nil
     end
   end
+  def line_for(_, _), do: nil
 
   @doc """
   Adds a message to the program. Messages are added at the end of the list.

--- a/lib/dungeon_crawl/scripting/program.ex
+++ b/lib/dungeon_crawl/scripting/program.ex
@@ -2,7 +2,17 @@ defmodule DungeonCrawl.Scripting.Program do
   @doc """
   A struct containing the representation of a program and its state.
   """
-  defstruct status: :dead, pc: 1, lc: 0, instructions: %{}, labels: %{}, locked: false, broadcasts: [], responses: [], wait_cycles: 0, messages: []
+  defstruct status: :dead,
+            pc: 1,
+            lc: 0,
+            instructions: %{},
+            labels: %{},
+            locked: false,
+            broadcasts: [],
+            responses: [],
+            wait_cycles: 0,
+            messages: [],
+            timed_messages: []
 
   @doc """
   Returns the line number for the given active label for the program.
@@ -27,12 +37,15 @@ defmodule DungeonCrawl.Scripting.Program do
   end
 
   @doc """
-  Adds a message to the program. The program can only accept one message. If the message
-  field is already taken, no change is made.
+  Adds a message to the program.
   """
-  def send_message(program, label, sender \\ nil) do
+  def send_message(program, label, sender, 0) do
     # TODO: Probably want to have the programs be their own separate processes eventually.
     messages = Enum.reverse([{label, sender} | Enum.reverse(program.messages) ])
     %{ program | messages: messages }
+  end
+  def send_message(program, label, sender, delay) do
+    trigger_time = Time.utc_now |> Time.add(delay, :second)
+    %{ program | timed_messages: [{trigger_time, label, sender} | program.timed_messages] }
   end
 end

--- a/lib/dungeon_crawl/scripting/program.ex
+++ b/lib/dungeon_crawl/scripting/program.ex
@@ -37,7 +37,7 @@ defmodule DungeonCrawl.Scripting.Program do
   end
 
   @doc """
-  Adds a message to the program.
+  Adds a message to the program. Messages are added at the end of the list.
   """
   def send_message(program, label, sender, 0) do
     # TODO: Probably want to have the programs be their own separate processes eventually.

--- a/lib/dungeon_crawl/scripting/program_validator.ex
+++ b/lib/dungeon_crawl/scripting/program_validator.ex
@@ -254,6 +254,9 @@ defmodule DungeonCrawl.Scripting.ProgramValidator do
   defp _validate(program, [ {_line_no, [:send_message, [_label, _target] ]} | instructions], errors, user) do
     _validate(program, instructions, errors, user)
   end
+  defp _validate(program, [ {_line_no, [:send_message, [_label, _target, _delay] ]} | instructions], errors, user) do
+    _validate(program, instructions, errors, user)
+  end
   defp _validate(program, [ {line_no, [:send_message, _ ]} | instructions], errors, user) do
     _validate(program, instructions, ["Line #{line_no}: SEND command has an invalid number of parameters" | errors], user)
   end

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -81,6 +81,8 @@ Logger.info inspect runner_state.event_sender
 Logger.info "instance state:"
 Logger.info inspect state.state_values
 Logger.info "msg_count: " <> inspect(runner_state.msg_count)
+Logger.info inspect program.timed_messages
+Logger.info inspect program.messages
 # coveralls-ignore-stop
 end
 

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -28,6 +28,17 @@ require Logger
   end
 
   def run(%Runner{program: program, object_id: object_id, state: state, msg_count: msg_count} = runner_state) do
+    runner_state =
+      if program.timed_messages != [] do
+        {triggered, timed_messages} = Enum.split_with(program.timed_messages, fn {trigger_time, _label, _} ->
+          Time.compare(Time.utc_now, trigger_time) != :lt
+        end)
+        triggered = Enum.map(triggered, fn {_, message, sender} -> {message, sender} end)
+        %{ runner_state | program: %{ program | messages: program.messages ++ triggered, timed_messages: timed_messages}}
+      else
+        runner_state
+      end
+
     cond do
       program.messages == [] || program.status == :alive || program.status == :dead ->
         # todo: maybe have the check for active tile live elsewhere

--- a/lib/dungeon_crawl_web/channels/level_channel.ex
+++ b/lib/dungeon_crawl_web/channels/level_channel.ex
@@ -136,7 +136,7 @@ defmodule DungeonCrawlWeb.LevelChannel do
            true <- Levels.valid_message_action?(instance_state, player_tile.id, label),
            event_sender <- Map.merge(player_location, Map.take(player_tile, [:parsed_state])) do
         instance_state = Levels.remove_message_actions(instance_state, player_tile.id)
-                         |> Levels.send_event(target_tile, label, event_sender)
+                         |> Levels.send_event(target_tile, label, event_sender, 0)
         {:ok, instance_state}
       else
         _ -> {:ok, instance_state}
@@ -295,7 +295,7 @@ defmodule DungeonCrawlWeb.LevelChannel do
         toucher = Map.merge(player_location, Map.take(player_tile, [:name, :parsed_state]))
         instance_state = target_tiles
                          |> Enum.reduce(instance_state, fn(target_tile, instance_state) ->
-                               Levels.send_event(instance_state, target_tile, "TOUCH", toucher)
+                               Levels.send_event(instance_state, target_tile, "TOUCH", toucher, 0)
                              end)
         toucher_after_event = Levels.get_tile_by_id(instance_state, player_tile)
         if toucher_after_event && Map.take(toucher_after_event, [:row, :col]) == Map.take(player_tile, [:row, :col]) do
@@ -322,7 +322,7 @@ defmodule DungeonCrawlWeb.LevelChannel do
         if !Levels.responds_to_event?(instance_state, target_tile, action) && unhandled_event_message do
           DungeonCrawlWeb.Endpoint.broadcast "players:#{player_location.id}", "message", %{message: unhandled_event_message}
         end
-        instance_state = Levels.send_event(instance_state, target_tile, action, Map.merge(player_location, Map.take(player_tile, [:name, :parsed_state])))
+        instance_state = Levels.send_event(instance_state, target_tile, action, Map.merge(player_location, Map.take(player_tile, [:name, :parsed_state])), 0)
 
         {:ok, instance_state}
       else

--- a/lib/dungeon_crawl_web/templates/page/reference.html.eex
+++ b/lib/dungeon_crawl_web/templates/page/reference.html.eex
@@ -968,9 +968,16 @@
           </tr>
           <tr id="send">
             <td>SEND</td>
-            <td>list - 1 or two</td>
+            <td>list - 1 to 3</td>
             <td>Sends a message. A message can be sent to the current running program, or to another program.
                 The first parameter is the message to send, and the second (optional) param is the target.
+                The third (optional) param is the delay for the message. Default is zero (which sends the
+                message immediately). A positive integer is the number of seconds to wait before triggering
+                the message after the command is run. This is useful for when a player will not be hanging out
+                in the level, and there are events that still need to happen after a period of time.
+                Using the idle, ?i, movement could be used for a similar delay, however those idle commands
+                will not run when the instance is idle and so it would make that even take longer to occur
+                (provided the level is active at all).
                 Both the label and the name are case insensitive. Valid targets include: self (this is used
                 when no target explicitly given), all (all running scripts will be sent this message, including
                 this one), others (all other running scripts will be sent this message), a direction, the name of
@@ -983,7 +990,8 @@
             <td colspan="3" class="examples">
                 <pre class="script">#SEND touch, ?sender</pre>
                 <pre class="script">#SEND close, all</pre>
-                <pre class="script">#SEND done</pre></td>
+                <pre class="script">#SEND done</pre>
+                <pre class="script">#SEND grow, self, 60</pre></td>
           </tr>
           <tr id="sequence">
             <td>SEQUENCE</td>

--- a/test/dungeon_crawl/dungeon_processes/level_process_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/level_process_test.exs
@@ -451,7 +451,8 @@ defmodule DungeonCrawl.LevelProcessTest do
         %{character: "O", row: 1, col: 4, z_index: 0, state: "health: 10, points: 9", name: "a nonprog"},
         %{character: "O", row: 1, col: 9, z_index: 0, state: "destroyable: true, points: 5", name: "another nonprog"},
         %{character: "O", row: 1, col: 5, z_index: 0, script: "#SEND shot, worthless nonprog", state: "destroyable: true, owner: 23423, points: 3", name: "worthless nonprog"},
-        %{character: "@", row: 1, col: 3, z_index: 0, script: "#SEND shot, a nonprog", state: "damage: 10", name: "player"}
+        %{character: "@", row: 1, col: 3, z_index: 0, script: "#SEND shot, a nonprog", state: "damage: 10", name: "player"},
+        %{character: "O", row: 9, col: 9, z_index: 0, script: "#SEND shot, delayed nonprog, 1", state: "destroyable: true, owner: 23423, points: 3", name: "delayed nonprog"},
       ]
       |> Enum.map(fn(mt) -> Map.merge(mt, %{level_instance_id: level_instance.id}) end)
       |> Enum.map(fn(mt) -> DungeonInstances.create_tile!(mt) end)
@@ -461,6 +462,7 @@ defmodule DungeonCrawl.LevelProcessTest do
     destroyable_tile = Enum.at(tiles, 2)
     worthless_tile = Enum.at(tiles, 3)
     player_tile = Enum.at(tiles, 4)
+    delayed_nonprog = Enum.at(tiles, 5)
 
     player_location = %Location{id: 555, tile_instance_id: player_tile.id}
     player_channel = "players:#{player_location.id}"
@@ -482,6 +484,7 @@ defmodule DungeonCrawl.LevelProcessTest do
     refute map_by_ids[worthless_tile.id]
     refute map_by_ids[damager_tile.id].parsed_state[:score]
     assert map_by_ids[player_tile.id].parsed_state[:score] == 14
+    assert map_by_ids[delayed_nonprog.id] # the delayed message does not fire right away
 
     assert_receive %Phoenix.Socket.Broadcast{
             topic: ^player_channel,

--- a/test/dungeon_crawl/dungeon_processes/level_process_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/level_process_test.exs
@@ -160,7 +160,7 @@ defmodule DungeonCrawl.LevelProcessTest do
     refute LevelProcess.responds_to_event?(instance_process, tile_id-1, "ANYTHING")
   end
 
-  test "send_event/3", %{instance_process: instance_process, tile_id: tile_id} do
+  test "send_event/4", %{instance_process: instance_process, tile_id: tile_id} do
     scripted_tile_1 = %Tile{id: 236, character: "O", row: 1, col: 2, z_index: 0, script: "#end\n:alert\n#become color: red"}
     scripted_tile_2 = %Tile{id: 237, character: "O", row: 1, col: 3, z_index: 0, script: "#end\n:alert\n#become color: yellow"}
     inert_tile = %Tile{id: 238, character: "O", row: 1, col: 3, z_index: 0, script: "#end\n:alert\n#become color: yellow"}
@@ -172,17 +172,27 @@ defmodule DungeonCrawl.LevelProcessTest do
     %Levels{ program_contexts: program_contexts } = LevelProcess.get_state(instance_process)
 
     # sends the message to all running programs
-    LevelProcess.send_event(instance_process, "TOUCH", sender)
+    LevelProcess.send_event(instance_process, "TOUCH", sender, 0)
     %Levels{ program_contexts: ^program_contexts,
              program_messages: program_messages } = LevelProcess.get_state(instance_process)
 
-    assert Enum.member?(program_messages, {tile_id, "TOUCH", sender})
-    assert Enum.member?(program_messages, {scripted_tile_1.id, "TOUCH", sender})
-    assert Enum.member?(program_messages, {scripted_tile_2.id, "TOUCH", sender})
-    refute Enum.member?(program_messages, {inert_tile.id, "TOUCH", sender})
+    assert Enum.member?(program_messages, {tile_id, "TOUCH", sender, 0})
+    assert Enum.member?(program_messages, {scripted_tile_1.id, "TOUCH", sender, 0})
+    assert Enum.member?(program_messages, {scripted_tile_2.id, "TOUCH", sender, 0})
+    refute Enum.member?(program_messages, {inert_tile.id, "TOUCH", sender, 0})
+
+    # sends the message to all running programs
+    LevelProcess.send_event(instance_process, "TOUCH", sender, 10)
+    %Levels{ program_contexts: ^program_contexts,
+      program_messages: program_messages } = LevelProcess.get_state(instance_process)
+
+    assert Enum.member?(program_messages, {tile_id, "TOUCH", sender, 10})
+    assert Enum.member?(program_messages, {scripted_tile_1.id, "TOUCH", sender, 10})
+    assert Enum.member?(program_messages, {scripted_tile_2.id, "TOUCH", sender, 10})
+    refute Enum.member?(program_messages, {inert_tile.id, "TOUCH", sender, 10})
   end
 
-  test "send_event/4", %{instance_process: instance_process, tile_id: tile_id} do
+  test "send_event/5", %{instance_process: instance_process, tile_id: tile_id} do
     player_location = %Location{id: 555}
 
     player_channel = "players:#{player_location.id}"
@@ -193,14 +203,14 @@ defmodule DungeonCrawl.LevelProcessTest do
              map_by_coords: _ } = LevelProcess.get_state(instance_process)
 
     # noop if it tile doesnt have a program
-    LevelProcess.send_event(instance_process, 111, "TOUCH", player_location)
+    LevelProcess.send_event(instance_process, 111, "TOUCH", player_location, 0)
     %Levels{ program_contexts: %{^tile_id => %{program: same_program} },
              map_by_ids: _,
              map_by_coords: _ } = LevelProcess.get_state(instance_process)
     assert program == same_program
 
     # it does something
-    LevelProcess.send_event(instance_process, tile_id, "TOUCH", player_location)
+    LevelProcess.send_event(instance_process, tile_id, "TOUCH", player_location, 0)
     %Levels{ program_contexts: %{^tile_id => %{program: updated_program} },
              map_by_ids: _,
              map_by_coords: _ } = LevelProcess.get_state(instance_process)
@@ -210,8 +220,17 @@ defmodule DungeonCrawl.LevelProcessTest do
             event: "message",
             payload: %{message: "Hey"}}
 
+    # Sending an event with a delayed does the thing
+    LevelProcess.send_event(instance_process, "TOUCH", %{id: tile_id}, 30)
+    %Levels{ program_contexts: %{^tile_id => %{program: updated_program} },
+      map_by_ids: _,
+      map_by_coords: _,
+      program_messages: program_messages } = LevelProcess.get_state(instance_process)
+    assert [{tile_id, "TOUCH", %{id: tile_id}, 30}] == program_messages
+    refute program == updated_program
+
     # prunes the program if died during the run of the label
-    LevelProcess.send_event(instance_process, tile_id, "TERMINATE", player_location)
+    LevelProcess.send_event(instance_process, tile_id, "TERMINATE", player_location, 0)
     %Levels{ program_contexts: %{} ,
              map_by_ids: _,
              map_by_coords: _ } = LevelProcess.get_state(instance_process)

--- a/test/dungeon_crawl/ecto_program_contexts_test.exs
+++ b/test/dungeon_crawl/ecto_program_contexts_test.exs
@@ -17,7 +17,8 @@ defmodule DungeonCrawl.EctoProgramContextsTest do
         pc: 0,
         responses: [],
         status: :idle,
-        wait_cycles: 0
+        wait_cycles: 0,
+        timed_messages: []
       }
     },
     3571817 => %{
@@ -101,7 +102,8 @@ defmodule DungeonCrawl.EctoProgramContextsTest do
         pc: 0,
         responses: [],
         status: :active,
-        wait_cycles: 0
+        wait_cycles: 0,
+        timed_messages: []
       }
     }
   }
@@ -125,7 +127,8 @@ defmodule DungeonCrawl.EctoProgramContextsTest do
         "pc" => 0,
         "responses" => [],
         "status" => ["__ATOM__", "idle"],
-        "wait_cycles" => 0
+        "wait_cycles" => 0,
+        "timed_messages" => []
       }
     },
     "3571817" => %{
@@ -209,7 +212,8 @@ defmodule DungeonCrawl.EctoProgramContextsTest do
         "pc" => 0,
         "responses" => [],
         "status" => ["__ATOM__", "active"],
-        "wait_cycles" => 0
+        "wait_cycles" => 0,
+        "timed_messages" => []
       }
     }
   }

--- a/test/dungeon_crawl/scripting/command_test.exs
+++ b/test/dungeon_crawl/scripting/command_test.exs
@@ -1627,8 +1627,8 @@ defmodule DungeonCrawl.Scripting.CommandTest do
 
     # when sent as a timed message
     %Runner{state: state} = Command.send_message(%Runner{state: state, program: program, object_id: stubbed_object.id}, ["tap", "others", 45])
-    assert state.program_messages == [{9001, "tap", stubbed_sender, 45}, {55, "tap", stubbed_sender, 45}, {1, "tap", stubbed_sender, 45},
-             {9001, "tap", stubbed_sender}, {55, "tap", stubbed_sender}, {1, "tap", stubbed_sender}]
+    assert state.program_messages == [{9001, "tap", stubbed_sender}, {55, "tap", stubbed_sender}, {1, "tap", stubbed_sender},
+             {1, "tap", stubbed_sender, 45}, {55, "tap", stubbed_sender, 45}, {9001, "tap", stubbed_sender, 45}]
   end
 
   test "SEND message to all" do

--- a/test/dungeon_crawl/scripting/command_test.exs
+++ b/test/dungeon_crawl/scripting/command_test.exs
@@ -1579,6 +1579,18 @@ defmodule DungeonCrawl.Scripting.CommandTest do
     assert state.program_messages == [{1337, "tap", stubbed_id}, {1337, "touch", stubbed_id}]
   end
 
+  test "SEND message to self with delay" do
+    program = program_fixture()
+    stubbed_object = Map.put(%Tile{id: 1337}, :parsed_state, %{})
+    state = %Levels{map_by_ids: %{1337 => stubbed_object}}
+    stubbed_id = %{tile_id: stubbed_object.id, parsed_state: stubbed_object.parsed_state}
+
+    %Runner{state: state, program: program} = Command.send_message(%Runner{program: program, object_id: stubbed_object.id, state: state}, ["tap", "self", 15])
+    assert state.program_messages == []
+    assert [{trigger_time, "tap", ^stubbed_id}] = program.timed_messages
+    assert_in_delta Time.diff(trigger_time, Time.utc_now), 15, 1
+  end
+
   test "SEND message to event sender" do
     sender = %{tile_id: 9001}
     stubbed_object = Map.put(%Tile{id: 1337, name: "test"}, :parsed_state, %{})
@@ -1612,6 +1624,11 @@ defmodule DungeonCrawl.Scripting.CommandTest do
 
     %Runner{state: state} = Command.send_message(%Runner{state: state, program: program, object_id: stubbed_object.id}, ["tap", "others"])
     assert state.program_messages == [{9001, "tap", stubbed_sender}, {55, "tap", stubbed_sender}, {1, "tap", stubbed_sender}]
+
+    # when sent as a timed message
+    %Runner{state: state} = Command.send_message(%Runner{state: state, program: program, object_id: stubbed_object.id}, ["tap", "others", 45])
+    assert state.program_messages == [{9001, "tap", stubbed_sender, 45}, {55, "tap", stubbed_sender, 45}, {1, "tap", stubbed_sender, 45},
+             {9001, "tap", stubbed_sender}, {55, "tap", stubbed_sender}, {1, "tap", stubbed_sender}]
   end
 
   test "SEND message to all" do
@@ -1666,9 +1683,23 @@ defmodule DungeonCrawl.Scripting.CommandTest do
     assert %{program_messages: program_messages_1} = LevelProcess.get_state(instance_process_1)
     assert %{program_messages: program_messages_2} = LevelProcess.get_state(instance_process_2)
 
-    assert Enum.member? program_messages_1, {prog1_id, "dance", expected_sender}
-    assert Enum.member? program_messages_1, {prog2_id, "dance", expected_sender}
-    assert Enum.member? program_messages_2, {prog3_id, "dance", expected_sender}
+    assert Enum.member? program_messages_1, {prog1_id, "dance", expected_sender, 0}
+    assert Enum.member? program_messages_1, {prog2_id, "dance", expected_sender, 0}
+    assert Enum.member? program_messages_2, {prog3_id, "dance", expected_sender, 0}
+
+    # Send timed message globally
+    LevelProcess.run_with(instance_process_1, fn (state) ->
+      object = Levels.get_tile(state, %{row: 1, col: 3})
+      %Runner{state: state} = Command.send_message(%Runner{state: state, object_id: object.id}, ["dance2", "global", 120])
+      {:ok, state}
+    end)
+
+    assert %{program_messages: program_messages_1} = LevelProcess.get_state(instance_process_1)
+    assert %{program_messages: program_messages_2} = LevelProcess.get_state(instance_process_2)
+
+    assert Enum.member? program_messages_1, {prog1_id, "dance2", expected_sender, 120}
+    assert Enum.member? program_messages_1, {prog2_id, "dance2", expected_sender, 120}
+    assert Enum.member? program_messages_2, {prog3_id, "dance2", expected_sender, 120}
 
     # cleanup
     DungeonRegistry.remove(DungeonInstanceRegistry, stubbed_dungeon_instance.id)

--- a/test/dungeon_crawl/scripting/program_test.exs
+++ b/test/dungeon_crawl/scripting/program_test.exs
@@ -19,6 +19,9 @@ defmodule DungeonCrawl.Scripting.ProgramTest do
 
       {:ok, program} = Parser.parse("")
       refute Program.line_for(program, "touch")
+
+      # returns nil for a non binary "label" or parsed value
+      refute Program.line_for(program, 4)
   end
 
   test "send_message/4 no delay" do

--- a/test/dungeon_crawl/scripting/program_test.exs
+++ b/test/dungeon_crawl/scripting/program_test.exs
@@ -21,12 +21,23 @@ defmodule DungeonCrawl.Scripting.ProgramTest do
       refute Program.line_for(program, "touch")
   end
 
-  test "send_message/2" do
-    program = Program.send_message(%Program{}, "touch", 1234)
+  test "send_message/4 no delay" do
+    program = Program.send_message(%Program{}, "touch", 1234, 0)
     assert [{"touch", 1234}] == program.messages
 
     # adds messages to the end of the list, FIFO
-    program = Program.send_message(program, "panic")
+    program = Program.send_message(program, "panic", nil, 0)
     assert [{"touch", 1234}, {"panic", nil}] == program.messages
+  end
+
+  test "send_message/4 with delay" do
+    program = Program.send_message(%Program{}, "touch", 1234, 120)
+    assert [{trigger_time, "touch", 1234}] = program.timed_messages
+    assert_in_delta Time.diff(trigger_time, Time.utc_now), 120, 1
+
+    program = Program.send_message(program, "panic", nil, 15)
+    assert [{t2, "panic", nil}, {t1, "touch", 1234}] = program.timed_messages
+    assert_in_delta Time.diff(t1, Time.utc_now), 120, 1
+    assert_in_delta Time.diff(t2, Time.utc_now), 15, 1
   end
 end

--- a/test/dungeon_crawl/scripting/program_validator_test.exs
+++ b/test/dungeon_crawl/scripting/program_validator_test.exs
@@ -66,7 +66,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidatorTest do
     #RESTORE THUD
     #SEND touch
     #SEND thud, all
-    #SEND hi, all, toomany
+    #SEND hi, all, 10, toomany
     #SEND touch, @facing
     #SHOOT @facing
     #SHOOT west
@@ -130,6 +130,7 @@ defmodule DungeonCrawl.Scripting.ProgramValidatorTest do
     #SOUND 123
     #SOUND bloop, yall
     #SOUND bloop, all, extra
+    #SEND touch, self, 30
     """
   end
 


### PR DESCRIPTION
Adding timed messages. These messages will act like normal messages, however instead of immediately triggering
when sent, they will be triggered after a delay. This will allow a message to occur at the proper time, even if the instance goes idle or is removed/saved and not running in a process.