### PR TITLE
using DateTime instead of Time for timed events

### DIFF
--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -1360,7 +1360,7 @@ defmodule DungeonCrawl.Scripting.Command do
                                                             state.program_messages] } }
   end
   defp _send_message(%Runner{state: state, program: program, object_id: object_id} = runner_state, [label, "self", delay]) do
-    trigger_time = Time.utc_now |> Time.add(delay, :second)
+    trigger_time = DateTime.utc_now |> DateTime.add(delay, :second)
     object = Levels.get_tile_by_id(state, %{id: object_id})
     timed_messages = Enum.reverse([
         {trigger_time, label, %{tile_id: object.id, state: object.state}}

--- a/lib/dungeon_crawl/scripting/program.ex
+++ b/lib/dungeon_crawl/scripting/program.ex
@@ -46,7 +46,7 @@ defmodule DungeonCrawl.Scripting.Program do
     %{ program | messages: messages }
   end
   def send_message(program, label, sender, delay) do
-    trigger_time = Time.utc_now |> Time.add(delay, :second)
+    trigger_time = DateTime.utc_now |> DateTime.add(delay, :second)
     %{ program | timed_messages: [{trigger_time, label, sender} | program.timed_messages] }
   end
 end

--- a/lib/dungeon_crawl/scripting/runner.ex
+++ b/lib/dungeon_crawl/scripting/runner.ex
@@ -31,7 +31,7 @@ require Logger
     runner_state =
       if program.timed_messages != [] do
         {triggered, timed_messages} = Enum.split_with(program.timed_messages, fn {trigger_time, _label, _} ->
-          Time.compare(Time.utc_now, trigger_time) != :lt
+          DateTime.compare(DateTime.utc_now, trigger_time) != :lt
         end)
         triggered = Enum.map(triggered, fn {_, message, sender} -> {message, sender} end)
         %{ runner_state | program: %{ program | messages: program.messages ++ triggered, timed_messages: timed_messages}}

--- a/test/dungeon_crawl/scripting/command_test.exs
+++ b/test/dungeon_crawl/scripting/command_test.exs
@@ -1585,8 +1585,8 @@ defmodule DungeonCrawl.Scripting.CommandTest do
     %Runner{state: state, program: program} = Command.send_message(runner_state, ["second_message", "self", 45])
     assert state.program_messages == []
     assert [{trigger_time_1, "tap", ^stubbed_id}, {trigger_time_2, "second_message", ^stubbed_id}] = program.timed_messages
-    assert_in_delta Time.diff(trigger_time_1, Time.utc_now), 15, 1
-    assert_in_delta Time.diff(trigger_time_2, Time.utc_now), 45, 1
+    assert_in_delta DateTime.diff(trigger_time_1, DateTime.utc_now), 15, 1
+    assert_in_delta DateTime.diff(trigger_time_2, DateTime.utc_now), 45, 1
   end
 
   test "SEND message to event sender" do

--- a/test/dungeon_crawl/scripting/program_test.exs
+++ b/test/dungeon_crawl/scripting/program_test.exs
@@ -36,11 +36,11 @@ defmodule DungeonCrawl.Scripting.ProgramTest do
   test "send_message/4 with delay" do
     program = Program.send_message(%Program{}, "touch", 1234, 120)
     assert [{trigger_time, "touch", 1234}] = program.timed_messages
-    assert_in_delta Time.diff(trigger_time, Time.utc_now), 120, 1
+    assert_in_delta DateTime.diff(trigger_time, DateTime.utc_now), 120, 1
 
     program = Program.send_message(program, "panic", nil, 15)
     assert [{t2, "panic", nil}, {t1, "touch", 1234}] = program.timed_messages
-    assert_in_delta Time.diff(t1, Time.utc_now), 120, 1
-    assert_in_delta Time.diff(t2, Time.utc_now), 15, 1
+    assert_in_delta DateTime.diff(t1, DateTime.utc_now), 120, 1
+    assert_in_delta DateTime.diff(t2, DateTime.utc_now), 15, 1
   end
 end

--- a/test/dungeon_crawl/scripting/runner_test.exs
+++ b/test/dungeon_crawl/scripting/runner_test.exs
@@ -74,8 +74,8 @@ defmodule DungeonCrawl.Scripting.RunnerTest do
       stubbed_object = %{id: 1, state: %{}}
       stubbed_state = %Levels{map_by_ids: %{ 1 => stubbed_object} }
 
-      future = Time.add(Time.utc_now, 100)
-      %Runner{program: run_program} = Runner.run(%Runner{program: %{program | timed_messages: [{future, "there", nil}, {Time.utc_now, "here", nil}], status: :idle}, object_id: 1, state: stubbed_state})
+      future = DateTime.add(DateTime.utc_now, 100)
+      %Runner{program: run_program} = Runner.run(%Runner{program: %{program | timed_messages: [{future, "there", nil}, {DateTime.utc_now, "here", nil}], status: :idle}, object_id: 1, state: stubbed_state})
       assert run_program.messages == [{"here", nil}]
       assert run_program.timed_messages == [{future, "there", nil}]
       assert run_program.responses == [] # the message would not have run yet


### PR DESCRIPTION
the date also needs taken into account; just using time can cause events to not fire when they should.
ie, even that should fire at 8pm would not fire if the time the level instance is reloaded is at 6am the next day.
This fixes that.

Note: There might be wierd errors when applying this update if there are existing saves/instances with pending timed messages. Just delete these or the json'd program_contexts to get rid of the error, then delete those running processes.