### PR TITLE
Bump count to idle on level lookup

### DIFF
--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -132,6 +132,13 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
   end
 
   @doc """
+  Resets the count_to_idle to the initial value
+  """
+  def reset_count_to_idle(instance) do
+    GenServer.call(instance, {:reset_count_to_idle})
+  end
+
+  @doc """
   Check is a tile/program responds to an event
   """
   def responds_to_event?(instance, tile_id, event) do
@@ -264,6 +271,11 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
   def handle_call({:get_tiles, {row, col, direction}}, _from, %Levels{} = state) do
     tiles = Levels.get_tiles(state, %{row: row, col: col}, direction)
     {:reply, tiles, state}
+  end
+
+  @impl true
+  def handle_call({:reset_count_to_idle}, _from, state) do
+    {:reply, :ok, %{state | count_to_idle: 5}}
   end
 
   @impl true

--- a/lib/dungeon_crawl/dungeon_processes/level_registry.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_registry.ex
@@ -159,9 +159,14 @@ defmodule DungeonCrawl.DungeonProcesses.LevelRegistry do
     case Map.fetch(level_numbers, level_number) do
       {:ok, instance_ids} ->
         owner_key = if Map.has_key?(instance_ids, nil), do: nil, else: owner_id
-        # TODO: in the time that lookup returns a result, the process could time out with no players
-        # present. Make the lookup alo "touch" the instance process to reset the "count to idle"
-        {:reply, Map.fetch(instance_ids, owner_key), level_registry}
+
+        with {:ok, {_id, pid}} = resp <- Map.fetch(instance_ids, owner_key) do
+          if Process.alive?(pid), do: LevelProcess.reset_count_to_idle(pid)
+          {:reply, resp, level_registry}
+        else
+          other_result ->
+            {:reply, other_result, level_registry}
+        end
       _ ->
         {:reply, :error, level_registry}
     end

--- a/test/dungeon_crawl/dungeon_processes/level_process_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/level_process_test.exs
@@ -155,6 +155,12 @@ defmodule DungeonCrawl.LevelProcessTest do
             } = programs
   end
 
+  test "reset_count_to_idle/1", %{instance_process: instance_process} do
+    LevelProcess.run_with(instance_process, fn(state) -> {:ok, %{ state | count_to_idle: 1 }} end)
+    assert :ok = LevelProcess.reset_count_to_idle((instance_process))
+    assert %{count_to_idle: 5} = LevelProcess.get_state(instance_process)
+  end
+
   test "responds_to_event?", %{instance_process: instance_process, tile_id: tile_id} do
     assert LevelProcess.responds_to_event?(instance_process, tile_id, "TOUCH")
     refute LevelProcess.responds_to_event?(instance_process, tile_id, "SNIFF")

--- a/test/dungeon_crawl/dungeon_processes/level_process_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/level_process_test.exs
@@ -36,6 +36,8 @@ defmodule DungeonCrawl.LevelProcessTest do
     LevelProcess.load_level(instance_process, [tile])
     LevelProcess.set_state_values(instance_process, %{"rows" => 20, "cols" => 20})
 
+    on_exit(fn -> Process.exit(instance_process, :kill) end)
+
     %{instance_process: instance_process, tile_id: tile.id, level_instance: level_instance}
   end
 

--- a/test/dungeon_crawl/dungeon_processes/level_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/level_registry_test.exs
@@ -12,6 +12,9 @@ defmodule DungeonCrawl.LevelRegistryTest do
       id: TestInstanceRegistry,
       start: {LevelRegistry, :start_link, [nil, []]}
     })
+
+    on_exit(fn -> Process.exit(instance_registry, :kill) end)
+
     %{instance_registry: instance_registry}
   end
 

--- a/test/dungeon_crawl/dungeon_processes/level_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/level_registry_test.exs
@@ -72,6 +72,19 @@ defmodule DungeonCrawl.LevelRegistryTest do
     assert {:ok, instance_id_and_process} != LevelRegistry.lookup_or_create(instance_registry, instance.number, nil)
   end
 
+  test "lookup reset the count to idle as a side effect", %{instance_registry: instance_registry} do
+    instance = insert_stubbed_level_instance()
+    LevelRegistry.set_dungeon_instance_id(instance_registry, instance.dungeon_instance_id)
+    LevelRegistry.create(instance_registry, instance.number, 1)
+    assert {:ok, {instance_id, instance_pid}} = LevelRegistry.lookup(instance_registry, instance.number, nil)
+    LevelProcess.run_with(instance_pid, fn(state) -> {:ok, %{ state | count_to_idle: 1 }} end)
+    assert %{count_to_idle: 1} = LevelProcess.get_state(instance_pid)
+
+    #the actual test, PID should not change, but mainly we care that the count to idle was reset to 5
+    assert {:ok, {instance_id, instance_pid}} == LevelRegistry.lookup(instance_registry, instance.number, nil)
+    assert %{count_to_idle: 5} = LevelProcess.get_state(instance_pid)
+  end
+
   test "create/2", %{instance_registry: instance_registry} do
     user = insert_user()
     button_tile = insert_tile_template(%{state: %{"blocking" => true}, script: "#END\n:TOUCH\n*PimPom*"})


### PR DESCRIPTION
On rare occurrances, a lookup of a level process could return an active PID, only for it to idle out right before a player joins.
This ensures that when a level process is looked up, it resets the count to idle so that the level process will stay alive longer, and allow the player to join. Otherwise, it the join may crash (ie, the player moving from one level to another will fail) and the destination level process will be recreated with sometimes unusual results (ie, the player in a random position rather than an entry point/passage exit)