### PR TITLE
Test process cleanup

### DIFF
--- a/test/dungeon_crawl/scripting/command_test.exs
+++ b/test/dungeon_crawl/scripting/command_test.exs
@@ -251,6 +251,9 @@ defmodule DungeonCrawl.Scripting.CommandTest do
     assert 1000 == DungeonProcess.get_state_value(map_set_process, "di_thing1")
     assert "well ok" == DungeonProcess.get_state_value(map_set_process, "di_flag")
     assert 5 == DungeonProcess.get_state_value(map_set_process, "b")
+
+    # cleanup
+    DungeonRegistry.remove(DungeonInstanceRegistry, state.dungeon_instance_id)
   end
 
   test "CHANGE_OTHER_STATE" do
@@ -1362,6 +1365,9 @@ defmodule DungeonCrawl.Scripting.CommandTest do
     {:ok, map_set_process} = DungeonRegistry.lookup_or_create(DungeonInstanceRegistry, state.dungeon_instance_id)
 
     assert Enum.member?(["test", "check"], DungeonProcess.get_state_value(map_set_process, "levelset_me"))
+
+    # cleanup
+    DungeonRegistry.remove(DungeonInstanceRegistry, state.dungeon_instance_id)
   end
 
   test "REPLACE tile in a direction" do

--- a/test/dungeon_crawl/scripting/command_test.exs
+++ b/test/dungeon_crawl/scripting/command_test.exs
@@ -237,7 +237,7 @@ defmodule DungeonCrawl.Scripting.CommandTest do
       Command.change_level_instance_state(%Runner{state: state}, ["fog_range", "=", 2])
   end
 
-  test "CHANGE_MAP_SET_INSTANCE_STATE" do
+  test "CHANGE_DUNGEON_INSTANCE_STATE" do
     dungeon_instance = insert_stubbed_dungeon_instance(%{state: %{"di_thing1" => 999, "di_flag" => false}})
     state = %Levels{state_values: %{"a" => 5}, dungeon_instance_id: dungeon_instance.id}
     {_tile, state} = Levels.create_tile(state, %Tile{id: 123, row: 1, col: 2, character: "."})
@@ -553,6 +553,7 @@ defmodule DungeonCrawl.Scripting.CommandTest do
     # cleanup
     :code.purge levels_mock_mod
     :code.delete levels_mock_mod
+    DungeonRegistry.remove(DungeonInstanceRegistry, state.dungeon_instance_id)
   end
 
   test "GAMEOVER with bad target doesnt crash game" do
@@ -576,6 +577,9 @@ defmodule DungeonCrawl.Scripting.CommandTest do
     # doesn't crash when given bad player (ie player already left)
     assert runner_state == Command.gameover(runner_state, [true, "ok", {:state_variable, "nothing"}])
     refute_receive %Phoenix.Socket.Broadcast{}
+
+    #cleanup
+    DungeonRegistry.remove(DungeonInstanceRegistry, state.dungeon_instance_id)
   end
 
   test "GIVE" do

--- a/test/dungeon_crawl_web/controllers/admin/dungeon_controller_test.exs
+++ b/test/dungeon_crawl_web/controllers/admin/dungeon_controller_test.exs
@@ -3,6 +3,7 @@ defmodule DungeonCrawlWeb.Admin.DungeonControllerTest do
 
   alias DungeonCrawl.Dungeons
   alias DungeonCrawl.DungeonInstances
+  alias DungeonCrawl.DungeonProcesses.DungeonRegistry
   alias DungeonCrawl.Games
 
   import DungeonCrawl.GamesFixtures
@@ -64,6 +65,9 @@ defmodule DungeonCrawlWeb.Admin.DungeonControllerTest do
       assert html_response(updated_conn, 200) =~ "Saved Games"
       updated_conn = get conn, admin_dungeon_path(conn, :show, dungeon, instance_id: dungeon_instance.id, level: "#{level_instance.number}")
       assert html_response(updated_conn, 200) =~ "Dungeon: "
+
+      # cleanup
+      DungeonRegistry.remove(DungeonInstanceRegistry, dungeon_instance.id)
     end
 
     test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/test/dungeon_crawl_web/controllers/admin/dungeon_process_controller_test.exs
+++ b/test/dungeon_crawl_web/controllers/admin/dungeon_process_controller_test.exs
@@ -27,15 +27,19 @@ defmodule DungeonCrawlWeb.Admin.DungeonProcessControllerTest do
     setup [:admin_user]
 
     test "lists all entries on index", %{conn: conn} do
-      setup_dungeon_instance()
+      instance = setup_dungeon_instance()
       conn = get conn, admin_dungeon_process_path(conn, :index)
       assert html_response(conn, 200) =~ "Listing dungeon processes"
+
+      DungeonRegistry.remove(DungeonInstanceRegistry, instance.id)
     end
 
     test "shows chosen dungeon instance", %{conn: conn} do
       instance = setup_dungeon_instance()
       conn = get conn, admin_dungeon_process_path(conn, :show, instance.id)
       assert html_response(conn, 200) =~ "DB Backed Dungeon Process"
+
+      DungeonRegistry.remove(DungeonInstanceRegistry, instance.id)
     end
 
     test "shows chosen dungeon instance when no backing db instance", %{conn: conn} do
@@ -43,13 +47,17 @@ defmodule DungeonCrawlWeb.Admin.DungeonProcessControllerTest do
       DungeonInstances.delete_dungeon(instance)
       conn = get conn, admin_dungeon_process_path(conn, :show, instance.id)
       assert html_response(conn, 200) =~ "Orphaned Dungeon Process"
+
+      DungeonRegistry.remove(DungeonInstanceRegistry, instance.id)
     end
 
     test "redirects with a message when dungeon instance is nonexistent", %{conn: conn} do
-      setup_dungeon_instance()
+      instance = setup_dungeon_instance()
       conn = get conn, admin_dungeon_process_path(conn, :show, -1)
       assert redirected_to(conn) == admin_dungeon_process_path(conn, :index)
       assert Flash.get(conn.assigns.flash, :info) == "Dungeon instance process not found: `-1`"
+
+      DungeonRegistry.remove(DungeonInstanceRegistry, instance.id)
     end
 
     test "deletes chosen dungeon instance", %{conn: conn} do
@@ -59,6 +67,8 @@ defmodule DungeonCrawlWeb.Admin.DungeonProcessControllerTest do
 
       eventually assert DungeonInstances.get_dungeon(instance.id)
       eventually assert :error = DungeonRegistry.lookup(DungeonInstanceRegistry, instance.id)
+
+      DungeonRegistry.remove(DungeonInstanceRegistry, instance.id)
     end
   end
 

--- a/test/dungeon_crawl_web/controllers/admin/level_process_controller_test.exs
+++ b/test/dungeon_crawl_web/controllers/admin/level_process_controller_test.exs
@@ -70,7 +70,7 @@ defmodule DungeonCrawlWeb.Admin.LevelProcessControllerTest do
       assert redirected_to(conn) == admin_dungeon_process_path(conn, :show, instance.dungeon_instance_id)
 
       eventually assert DungeonInstances.get_level(instance.dungeon_instance_id, instance.number)
-      assert :error = LevelRegistry.lookup(instance_registry, instance.number, instance.player_location_id)
+      eventually assert :error = LevelRegistry.lookup(instance_registry, instance.number, instance.player_location_id)
     end
 
     test "deletes chosen solo instance", %{conn: conn} do


### PR DESCRIPTION
Some cleanup to ensure dungeon processes are stopped when the test completes. This is mainly
to prevent noise from a dangling process trying to write to the DB or do something else after the test
as started cleaning up resources no longer needed (such as DB connections)
There are probably still some that were missed and these changes are from a limited amount of time
spent cleaning.