### PR TITLE
Replace js alerts with non js blocking modal

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -45,6 +45,7 @@ import AvatarPreview from "./avatar_preview"
 import Sound from "./sound"
 import StateVariableSubform from "./state_variable_subform"
 import InviteLink from "./invite_link"
+import ConfirmationModal from "./confirmation_modal"
 
 Sound.init(zzfx)
 StateVariableSubform.init(document.getElementById("dungeon_state_variables"))
@@ -63,4 +64,5 @@ CharacterPicker.init(document.getElementById("show_character_picker"))
 CodemirrorWrapper.initOnTab(document.getElementById("tile_template_script"), document.getElementById("script-tab"))
 CodemirrorWrapper.init(document.getElementById("item_script"))
 CodemirrorWrapper.initDiff(document.getElementById("assetImportDiffList"))
+ConfirmationModal.init(document, document.getElementById("confirmationModal"))
 TileAnimation.init()

--- a/assets/js/confirmation_modal.js
+++ b/assets/js/confirmation_modal.js
@@ -1,0 +1,43 @@
+let ConfirmationModal = {
+  init(document, modalEl) { if(!document || !modalEl) { return }
+
+    this.$modal = $(modalEl)
+    this.$body = this.$modal.find("#confirmationModalBody")
+    this.$confirmButton = this.$modal.find(".action.btn")
+
+    $(document).on("click", "[data-confirm]", (event) => {
+      event.preventDefault()
+
+      this.$body.text(event.target.dataset["confirm"])
+      this.$confirmButton.attr("data-csrf", event.target.dataset["csrf"])
+      this.$confirmButton.attr("data-method", event.target.dataset["method"])
+      this.$confirmButton.attr("data-to", event.target.dataset["to"])
+      this.$modal.modal({show: true})
+    })
+
+    this.$modal.on("click", ".btn.action", (event) => {
+      if(event.target.dataset["method"] === "delete"){
+        $.delete(event.target.dataset["to"],
+          {_csrf_token: event.target.dataset["csrf"]})
+      } else {
+        $.post(event.target.dataset["to"],
+          {_csrf_token: event.target.dataset["csrf"]})
+      }
+    })
+
+    this.$modal.on('hide.bs.modal', () => {
+      this.resetModal()
+    })
+  },
+  resetModal() {
+    this.$body.text("")
+    this.$confirmButton.attr("data-csrf", "")
+    this.$confirmButton.attr("data-method", "")
+    this.$confirmButton.attr("data-to", "")
+  },
+  $modal: null,
+  $body: null,
+  $confirmButton: null
+}
+
+export default ConfirmationModal

--- a/assets/js/confirmation_modal.js
+++ b/assets/js/confirmation_modal.js
@@ -3,26 +3,24 @@ let ConfirmationModal = {
 
     this.$modal = $(modalEl)
     this.$body = this.$modal.find("#confirmationModalBody")
-    this.$confirmButton = this.$modal.find(".action.btn")
 
     $(document).on("click", "[data-confirm]", (event) => {
       event.preventDefault()
 
       this.$body.text(event.target.dataset["confirm"])
-      this.$confirmButton.attr("data-csrf", event.target.dataset["csrf"])
-      this.$confirmButton.attr("data-method", event.target.dataset["method"])
-      this.$confirmButton.attr("data-to", event.target.dataset["to"])
+      this.confirmationTarget = event.target
+
       this.$modal.modal({show: true})
     })
 
     this.$modal.on("click", ".btn.action", (event) => {
-      if(event.target.dataset["method"] === "delete"){
-        $.delete(event.target.dataset["to"],
-          {_csrf_token: event.target.dataset["csrf"]})
-      } else {
-        $.post(event.target.dataset["to"],
-          {_csrf_token: event.target.dataset["csrf"]})
-      }
+      // Dirty way of using the already listening UJS listener
+      // to do its thing; Simply copying the data attributes
+      // to the modal confirm button did not work, and it did
+      // not seem worthwhile to try and reimplement the handling
+      // of a data spiced link here
+      this.confirmationTarget.removeAttribute("data-confirm")
+      this.confirmationTarget.click()
     })
 
     this.$modal.on('hide.bs.modal', () => {
@@ -31,13 +29,11 @@ let ConfirmationModal = {
   },
   resetModal() {
     this.$body.text("")
-    this.$confirmButton.attr("data-csrf", "")
-    this.$confirmButton.attr("data-method", "")
-    this.$confirmButton.attr("data-to", "")
+    this.confirmationTarget = null
   },
   $modal: null,
   $body: null,
-  $confirmButton: null
+  confirmationTarget: null
 }
 
 export default ConfirmationModal

--- a/lib/dungeon_crawl_web/templates/layout/app.html.eex
+++ b/lib/dungeon_crawl_web/templates/layout/app.html.eex
@@ -50,6 +50,8 @@
       </div>
     </div>
 
+    <%= render("confirmation_modal.html", conn: @conn) %>
+
   </body>
   <script>window.logSocketMessages=<%= Mix.env() != :prod %></script>
   <script>window.userToken = "<%= assigns[:user_token] %>"</script>

--- a/lib/dungeon_crawl_web/templates/layout/confirmation_modal.html.eex
+++ b/lib/dungeon_crawl_web/templates/layout/confirmation_modal.html.eex
@@ -1,0 +1,14 @@
+<!-- Modal -->
+<div class="modal fade" tabindex="-1" role="dialog" id="confirmationModal" aria-labelledby="confirmationLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-body text-left" id="confirmationModalBody">
+      </div>
+
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn action btn-primary" data-dismiss="modal">Confirm</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/dungeon_crawl_web/templates/layout/confirmation_modal.html.eex
+++ b/lib/dungeon_crawl_web/templates/layout/confirmation_modal.html.eex
@@ -6,8 +6,8 @@
       </div>
 
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-        <button type="button" class="btn action btn-primary" data-dismiss="modal">Confirm</button>
+        <a type="button" class="btn btn-secondary" data-dismiss="modal" rel="nofollow">Cancel</a>
+        <a type="button" class="btn action btn-primary" data-dismiss="modal" rel="nofollow">Confirm</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
By replacing a blocking JS popup alert, the jquery modal allows JS to continue to run in the background which prevents certain misbehaviours (such as dozens of sounds playing all at once when the alert goes away) to letting map updates continue to happen while the user decides if they "want to really do that thing"