### PR TITLE
Sound bugfix

### DIFF
--- a/assets/js/level.js
+++ b/assets/js/level.js
@@ -205,7 +205,7 @@ let Level = {
     }
 
     this.levelChannel.push(action, payload)
-      .receive("moved", (_) => this.sound.playEffect(this.soundFootstep, this.soundEffectVolume / 100))
+      .receive("moved", (_) => this.sound.playEffect([...this.soundFootstep], this.soundEffectVolume / 100))
       .receive("error", e => console.log(e))
   },
   open(direction, shift = false){

--- a/assets/js/sound.js
+++ b/assets/js/sound.js
@@ -23,9 +23,10 @@ let Sound = {
     }
   },
   playEffect(params, volumeModifier = 1){
+    let soundEffect = [...params]
     // first param (position 0) is the volume, defaults to 1
-    params[0] = params[0] ? (params[0] * volumeModifier) : volumeModifier
-    this.zzfx(...params)
+    soundEffect[0] = soundEffect[0] ? (soundEffect[0] * volumeModifier) : volumeModifier
+    this.zzfx(...soundEffect)
   },
   paramsRegex: /-?\d*\.?\d*(?:,-?\d*\.?\d*){13,19}/, // up to 20 parameters
   zzfx: null

--- a/assets/js/sound.js
+++ b/assets/js/sound.js
@@ -23,10 +23,9 @@ let Sound = {
     }
   },
   playEffect(params, volumeModifier = 1){
-    let soundEffect = [...params]
     // first param (position 0) is the volume, defaults to 1
-    soundEffect[0] = soundEffect[0] ? (soundEffect[0] * volumeModifier) : volumeModifier
-    this.zzfx(...soundEffect)
+    params[0] = params[0] ? (params[0] * volumeModifier) : volumeModifier
+    this.zzfx(...params)
   },
   paramsRegex: /-?\d*\.?\d*(?:,-?\d*\.?\d*){13,19}/, // up to 20 parameters
   zzfx: null


### PR DESCRIPTION
Uses a copy of the canned sound for footsteps, as the `playEffect` function modifies the array. This is usually fine, as it most often is invoked from a socket message and the parameter is used once and done.