### PR TITLE
Dont render tile update if no visible change

### DIFF
--- a/assets/js/level_admin.js
+++ b/assets/js/level_admin.js
@@ -34,6 +34,11 @@ let LevelAdmin = {
     this.levelAdminChannel.join()
       .receive("ok", (resp) => {
         console.log("joined the dungeon admin channel!")
+
+        // rerender, as the first page load might be stale at this point, so tile updates
+        // may cause wierd artifacts
+        this.levelAdminChannel.push("rerender", {})
+          .receive("ok", resp => document.getElementById("level_admin").innerHTML = resp)
       })
       .receive("error", resp => console.log("join failed", resp))
 

--- a/test/dungeon_crawl/dungeon_processes/levels_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/levels_test.exs
@@ -60,20 +60,35 @@ defmodule DungeonCrawl.DungeonProcesses.LevelsTest do
 
   test "get_tile/2 gets the top tile at the given coordinates", %{state: state} do
     assert %{id: 999} = Levels.get_tile(state, %{row: 1, col: 2})
+    assert %{id: 999} = Levels.get_tile(state, %{"row" => 1, "col" => 2})
+  end
+
+  test "get_tile/2 with junk returns nil" do
+    refute Levels.get_tile(%{}, %{})
   end
 
   test "get_tile/3 gets the top tile in the given direction", %{state: state} do
     assert %{id: 997} = Levels.get_tile(state, %{row: 1, col: 2}, "east")
+    assert %{id: 997} = Levels.get_tile(state, %{"row" => 1, "col" => 2}, "east")
+    refute Levels.get_tile(%{}, %{}, "north")
+  end
+
+  test "get_tiles/2 gets the top tile at the given coordinates", %{state: state} do
+    assert [tile_1] = Levels.get_tiles(state, %{row: 1, col: 2})
+    assert %{id: 999} = tile_1
+    assert [tile_1] == Levels.get_tiles(state, %{"row" => 1, "col" => 2})
   end
 
   test "get_tiles/3 gets the tiles in the given direction", %{state: state} do
     assert [tile_1, tile_2] = Levels.get_tiles(state, %{row: 1, col: 2}, "east")
     assert %{id: 997} = tile_1
     assert %{id: 998} = tile_2
+    assert [tile_1, tile_2] == Levels.get_tiles(state, %{"row" => 1, "col" => 2}, "east")
   end
 
   test "get_tiles/3 gets empty array in the given direction", %{state: state} do
     assert [] == Levels.get_tiles(state, %{row: 1, col: 2}, "north")
+    assert [] == Levels.get_tiles(state, %{"row" => 1, "col" => 2}, "north")
   end
 
   test "get_tile_by_id/2 gets the tile for the id", %{state: state} do

--- a/test/dungeon_crawl/dungeon_processes/levels_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/levels_test.exs
@@ -347,9 +347,11 @@ defmodule DungeonCrawl.DungeonProcesses.LevelsTest do
   end
 
   test "update_tile_state/3", %{state: state} do
+    state = %{state | rerender_coords: %{}}
     tile = Levels.get_tile(state, %{id: 999, row: 1, col: 2})
     assert {tile, state} = Levels.update_tile_state(state, tile, %{"hamburders" => 4})
     assert tile.state["hamburders"] == 4
+    assert state.rerender_coords == %{}
 
     assert {tile, _state} = Levels.update_tile_state(state, tile, %{"coffee" => 2})
     assert tile.state["hamburders"] == 4
@@ -359,6 +361,7 @@ defmodule DungeonCrawl.DungeonProcesses.LevelsTest do
     assert {tile, updated_state} = Levels.update_tile_state(state, tile, %{"light_source" => true})
     assert tile.state["light_source"] == true
     assert updated_state.light_sources[tile.id] == true
+    assert updated_state.rerender_coords == %{}
 
     assert {tile, updated_state} = Levels.update_tile_state(updated_state, tile, %{"other" => false})
     assert tile.state["light_source"] == true
@@ -449,6 +452,28 @@ defmodule DungeonCrawl.DungeonProcesses.LevelsTest do
              status: :wait,
              wait_cycles: 0
            } = program
+  end
+
+  test "update_tile/3 does not flag the coordinate for rerender on nonvisible change", %{state: state} do
+    state = %{state | rerender_coords: %{}}
+    tile = Levels.get_tile(state, %{id: 999, row: 1, col: 2})
+    tile_id = tile.id
+    assert {updated_tile, state} = Levels.update_tile(state, tile, %{"script" => "#end", "name" => "none"})
+    assert %Tile{id: ^tile_id, script: "#end", name: "none"} = updated_tile
+    assert state.rerender_coords == %{}
+
+    assert {updated_tile, state} = Levels.update_tile(state, tile, %{"color" => tile.color})
+    assert updated_tile.color == tile.color
+    assert state.rerender_coords == %{}
+
+    assert {updated_tile, updated_state} = Levels.update_tile(state, tile, %{"color" => "light#{inspect tile.color}"})
+    assert updated_tile.color == "light#{inspect tile.color}"
+    assert updated_state.rerender_coords == %{%{row: 1, col: 2} => true}
+
+    assert {_, updated_state} = Levels.update_tile(state, tile, %{"row" => 10, "col" => 12})
+    assert updated_state.rerender_coords == %{
+             %{row: 1, col: 2} => true,
+             %{row: 10, col: 12} => true}
   end
 
   test "delete_player_tile/2 deletes the tile and unregisters player location", %{state: state} do

--- a/test/dungeon_crawl_web/channels/level_admin_channel_test.exs
+++ b/test/dungeon_crawl_web/channels/level_admin_channel_test.exs
@@ -50,6 +50,20 @@ defmodule DungeonCrawl.LevelAdminChannelTest do
     assert_reply ref, :ok, %{"hello" => "there"}
   end
 
+  test "rerender replies with a rerender", %{dungeon_instance: dungeon_instance, level_instance: level_instance} do
+    user = insert_user(%{is_admin: true, user_id_hash: "user_id_hash"})
+
+    {:ok, _, socket} =
+      socket(DungeonCrawlWeb.UserSocket, "user_id_hash", %{user_id_hash: user.user_id_hash})
+      |> subscribe_and_join(LevelAdminChannel, _admin_channel(dungeon_instance.id, level_instance))
+
+    ref = push socket, "rerender", %{}
+
+    level_table = DungeonCrawlWeb.SharedView.level_as_table(level_instance, level_instance.height, level_instance.width)
+
+    assert_reply ref, :ok, ^level_table
+  end
+
   defp _admin_channel(dungeon_instance_id, level_instance) do
     "level_admin:#{dungeon_instance_id}:#{level_instance.number}:#{level_instance.player_location_id}"
   end


### PR DESCRIPTION
Fixes some bugs for LevelAdmin
Reduces unnecessary tile_change messages when no visible changes have actually occurred