### PR TITLE
Modify how often a SHIFT command may move an object

### DIFF
--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -405,6 +405,7 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
             |> Render.rerender_tiles_for_admin()
             |> Sound.broadcast_sound_effects()
             |> Map.put(:rerender_coords, %{})
+            |> Map.put(:shifted_ids, %{})
             |> _check_for_players()
     elapsed_ms = :os.system_time(:millisecond) - start_ms
     if elapsed_ms > @timeout do

--- a/lib/dungeon_crawl/dungeon_processes/levels.ex
+++ b/lib/dungeon_crawl/dungeon_processes/levels.ex
@@ -34,7 +34,8 @@ defmodule DungeonCrawl.DungeonProcesses.Levels do
             author: nil,
             light_sources: %{},
             cache: nil,
-            sound_effects: []
+            sound_effects: [],
+            shifted_ids: %{}
 
   alias DungeonCrawl.Action.Move
   alias DungeonCrawl.DungeonInstances.Tile

--- a/lib/dungeon_crawl/scripting/command.ex
+++ b/lib/dungeon_crawl/scripting/command.ex
@@ -1493,7 +1493,7 @@ defmodule DungeonCrawl.Scripting.Command do
                       { Levels.get_tile(state, %{row: object.row + row_d, col: object.col + col_d}),
                         Levels.get_tile(state, %{row: object.row + dest_row_d, col: object.col + dest_col_d}) }
                     end)
-                 |> Enum.filter(fn({tile, _dest_tile}) -> tile && tile.state["pushable"] end)
+                 |> Enum.filter(fn({tile, _dest_tile}) -> tile && tile.state["pushable"] && !state.shifted_ids[tile.id] end)
                  |> Enum.reject(fn({_tile, dest_tile}) -> !dest_tile || dest_tile.state["blocking"] && !dest_tile.state["pushable"] end)
 
     {runner_state, _, tile_changes} = _shifting(runner_state, shiftables, %{})
@@ -1504,8 +1504,17 @@ defmodule DungeonCrawl.Scripting.Command do
                       |> Enum.map(fn { {row, col}, _tile } -> %{row: row, col: col} end)
                       |> Enum.reduce(state.rerender_coords, fn coords, rerender_coords -> Map.put(rerender_coords, coords, true) end)
 
+    rerender_ids = Enum.map(tile_changes, fn {_coord, tile} -> tile.id end)
+
+    shifted_tile_ids = shiftables
+                       |> Enum.map(fn {tile, _dest} -> {tile.id, true} end)
+                       |> Enum.reject(fn {tile_id, _} -> !Enum.member?(rerender_ids, tile_id) end)
+                       |> Enum.into(%{})
+
     %Runner{ runner_state |
-             state: %{ runner_state.state | rerender_coords: rerender_coords },
+             state: %{ runner_state.state |
+               rerender_coords: rerender_coords,
+               shifted_ids: Map.merge(runner_state.state.shifted_ids, shifted_tile_ids) }, # TODO: move shifted IDS to runner struct
              program: %{program |
                         status: :wait,
                         wait_cycles: object.state["wait_cycles"] || 5 } }


### PR DESCRIPTION
Prevent an object from being shifted more than once per program interpolation cycle.

This is to prevent an object from suddenly finding itself across the map after one cycle when next to conveyors (/) that each convey it once. Due to the order of execution, the object may move only once when on one side of a conveyor belt, but all the way to the end when on the other which was undesired.

```
x                x
//////   -> /////
     x         x
```

which should just be

```
x            x
//////   -> /////
     x         x
```