### PR TITLE
Fixing incorrect alias in NodeRegistry for the DungeonSupervisor

### DIFF
--- a/deploy.sh.example
+++ b/deploy.sh.example
@@ -7,9 +7,14 @@
 
 echo $PATH
 cd $HOME/dungeon_crawl
+echo checking out and pulling master
 git checkout master
 git pull
-git checkout $BRANCH
+if [ "$BRANCH" != "master" ]; then
+  echo checking out and pulling $BRANCH
+  git checkout $BRANCH
+  git pull
+fi
 whereis mix
 MIX_QUIET=true MIX_ENV=prod mix deps.get
 MIX_ENV=prod mix ecto.migrate

--- a/deploy.sh.example
+++ b/deploy.sh.example
@@ -11,7 +11,7 @@ git checkout master
 git pull
 git checkout $BRANCH
 whereis mix
-MIX_ENV=prod mix deps.get
+MIX_QUIET=true MIX_ENV=prod mix deps.get
 MIX_ENV=prod mix ecto.migrate
 MIX_ENV=prod mix assets.deploy
 sudo /bin/systemctl restart dungeon_crawl.service

--- a/envs/env.test
+++ b/envs/env.test
@@ -1,2 +1,3 @@
 DATABASE=dungeon_crawl_test
 PHX_SERVER=true
+PORT=

--- a/lib/dungeon_crawl/dungeon_processes/dungeon_registry.ex
+++ b/lib/dungeon_crawl/dungeon_processes/dungeon_registry.ex
@@ -75,8 +75,8 @@ defmodule DungeonCrawl.DungeonProcesses.DungeonRegistry do
   @impl true
   def handle_call({:lookup, dungeon_id}, _from, state) do
     result = \
-      case Registry.get_dungeon_process_meta({:dungeon_id, dungeon_id}) do
-        {:ok, {:pid, pid}} -> {:ok, pid}
+      case get_pid_from_dungeon_id(dungeon_id) do
+        {:ok, pid} -> {:ok, pid}
         _error -> :error
       end
     {:reply, result, state}
@@ -100,8 +100,8 @@ defmodule DungeonCrawl.DungeonProcesses.DungeonRegistry do
 
   @impl true
   def handle_cast({:create, dungeon_id}, state) do
-    case Registry.get_dungeon_process_meta({:dungeon_id, dungeon_id}) do
-      {:ok, {:pid, _pid}} ->
+    case get_pid_from_dungeon_id(dungeon_id) do
+      {:ok, _pid} ->
         {:noreply, state}
 
       _error ->
@@ -117,8 +117,8 @@ defmodule DungeonCrawl.DungeonProcesses.DungeonRegistry do
 
   @impl true
   def handle_cast({:remove, dungeon_id}, state) do
-    case Registry.get_dungeon_process_meta({:dungeon_id, dungeon_id}) do
-      {:ok, {:pid, pid}} -> GenServer.stop(pid, :shutdown)
+    case get_pid_from_dungeon_id(dungeon_id) do
+      {:ok, pid} -> GenServer.stop(pid, :shutdown)
       _ -> nil # nothing to do/already dead?
     end
 
@@ -164,6 +164,21 @@ defmodule DungeonCrawl.DungeonProcesses.DungeonRegistry do
        end)
 
     state
+  end
+
+  def get_pid_from_dungeon_id(id) do
+    with {:ok, {:pid, pid}} <- Registry.get_dungeon_process_meta({:dungeon_id, id}) do
+      if :rpc.call(node(pid), Process, :alive?, [pid]) do
+        {:ok, pid}
+      else
+        Logger.warning "PID #{ inspect pid } appears to be dead for dungeon id #{ id }; " <>
+                       "removing from metadata"
+        Registry.remove_dungeon_process_meta({:pid, pid})
+        :error
+      end
+    else
+      _ -> :error # nothing to do/already dead?
+    end
   end
 
   defp _via_tuple(name) do

--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -411,14 +411,19 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
   @impl true
   def handle_info(:perform_actions, %Levels{} = state) do
     start_ms = :os.system_time(:millisecond)
-    state = _cycle_programs(%{state | new_pids: []})
-            |> _broadcast_stat_updates()
-            |> Render.rerender_tiles()
-            |> Render.rerender_tiles_for_admin()
-            |> Sound.broadcast_sound_effects()
-            |> Map.put(:rerender_coords, %{})
-            |> Map.put(:shifted_ids, %{})
-            |> _check_for_players()
+    actions_task = Task.async(
+      fn() ->
+        _cycle_programs(%{state | new_pids: []})
+        |> _broadcast_stat_updates()
+        |> Render.rerender_tiles()
+        |> Render.rerender_tiles_for_admin()
+        |> Sound.broadcast_sound_effects()
+        |> Map.put(:rerender_coords, %{})
+        |> Map.put(:shifted_ids, %{})
+        |> _check_for_players()
+      end
+    )
+    state = Task.await(actions_task)
     elapsed_ms = :os.system_time(:millisecond) - start_ms
     if elapsed_ms > @timeout do
       Logger.warning "_cycle_programs for instance # #{state.instance_id} took #{(:os.system_time(:millisecond) - start_ms)} ms !!!"

--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -412,19 +412,14 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
   @impl true
   def handle_info(:perform_actions, %Levels{} = state) do
     start_ms = :os.system_time(:millisecond)
-    actions_task = Task.async(
-      fn() ->
-        _cycle_programs(%{state | new_pids: []})
-        |> _broadcast_stat_updates()
-        |> Render.rerender_tiles()
-        |> Render.rerender_tiles_for_admin()
-        |> Sound.broadcast_sound_effects()
-        |> Map.put(:rerender_coords, %{})
-        |> Map.put(:shifted_ids, %{})
-        |> _check_for_players()
-      end
-    )
-    state = Task.await(actions_task)
+    state = _cycle_programs(%{state | new_pids: []})
+            |> _broadcast_stat_updates()
+            |> Render.rerender_tiles()
+            |> Render.rerender_tiles_for_admin()
+            |> Sound.broadcast_sound_effects()
+            |> Map.put(:rerender_coords, %{})
+            |> Map.put(:shifted_ids, %{})
+            |> _check_for_players()
     elapsed_ms = :os.system_time(:millisecond) - start_ms
     if elapsed_ms > @timeout do
       Logger.warning "perform_actions for instance # #{state.instance_id} took #{(:os.system_time(:millisecond) - start_ms)} ms !!!"

--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -19,6 +19,7 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
   @timeout 50
   @inactive_player_timeout 60_000
   @player_torch_timeout 5_000
+  @write_db_timeout 180_000
 
   @doc """
   Starts the instance process.
@@ -478,11 +479,11 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
     {:noreply, state}
   end
 
-  # Currently, this is only being used by tests to hook into this module to test
-  # the _write_db_task function
   @impl true
   def handle_info(:write_db, %Levels{} = state) do
     if DungeonInstances.get_level(state.instance_id) do
+      Process.send_after(self(), :write_db, @write_db_timeout)
+
       _write_db_task(state)
     else
       Logger.info "instance # #{state.instance_id} no longer has a backing DB record; shutting down process"
@@ -512,6 +513,8 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
                  Levels.set_tile_id(state, tile, temp_id)
                end)
 
+    time_to_create = :os.system_time(:millisecond) - start_ms
+
     # save off this other stuff but don't block the GenServer, and dont care about the result
     Task.start(fn ->
       # :deleted
@@ -539,9 +542,12 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
         |> DungeonInstances.update_tiles()
       end
 
-      if :os.system_time(:millisecond) - start_ms > 200 do
-        Logger.info "write_db for instance # #{state.instance_id} took #{(:os.system_time(:millisecond) - start_ms)} ms"
-      end
+      total_time = (:os.system_time(:millisecond) - start_ms)
+      Logger.info "write_db for instance # #{state.instance_id} took #{total_time} ms\n" <>
+                  "  (creating: #{time_to_create} ms, updating/deleting: #{total_time - time_to_create} ms)\n" <>
+                  "  #{length(Map.keys(new_ids))} new tiles\n" <>
+                  "  #{length(updates)} updated tiles\n" <>
+                  "  #{length(deletes)} deleted tiles"
     end)
 
     {:noreply, %Levels{ state | dirty_ids: %{}, new_ids: %{}}}

--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -480,11 +480,13 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
 
   @impl true
   def handle_info(:garbage_collect, state) do
+    start_ms = :os.system_time(:millisecond)
     :erlang.garbage_collect()
+    Logger.warning "garbage_collect for instance # #{state.instance_id} took #{(:os.system_time(:millisecond) - start_ms)} ms"
 
     Process.send_after(self(), :garbage_collect, 300_000) # five minutes
 
-    {:noreply, state}
+    {:noreply, state, :hibernate}
   end
 
   # Currently, this is only being used by tests to hook into this module to test

--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -426,7 +426,7 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
     state = Task.await(actions_task)
     elapsed_ms = :os.system_time(:millisecond) - start_ms
     if elapsed_ms > @timeout do
-      Logger.warning "_cycle_programs for instance # #{state.instance_id} took #{(:os.system_time(:millisecond) - start_ms)} ms !!!"
+      Logger.warning "perform_actions for instance # #{state.instance_id} took #{(:os.system_time(:millisecond) - start_ms)} ms !!!"
     end
 
     Process.send_after(self(), :perform_actions, @timeout)
@@ -474,6 +474,15 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
     end)
 
     Process.send_after(self(), :player_torch_timeout, @player_torch_timeout)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:garbage_collect, state) do
+    :erlang.garbage_collect()
+
+    Process.send_after(self(), :garbage_collect, 300_000) # five minutes
 
     {:noreply, state}
   end

--- a/lib/dungeon_crawl/dungeon_processes/level_process.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_process.ex
@@ -478,17 +478,6 @@ defmodule DungeonCrawl.DungeonProcesses.LevelProcess do
     {:noreply, state}
   end
 
-  @impl true
-  def handle_info(:garbage_collect, state) do
-    start_ms = :os.system_time(:millisecond)
-    :erlang.garbage_collect()
-    Logger.warning "garbage_collect for instance # #{state.instance_id} took #{(:os.system_time(:millisecond) - start_ms)} ms"
-
-    Process.send_after(self(), :garbage_collect, 300_000) # five minutes
-
-    {:noreply, state, :hibernate}
-  end
-
   # Currently, this is only being used by tests to hook into this module to test
   # the _write_db_task function
   @impl true

--- a/lib/dungeon_crawl/dungeon_processes/level_registry.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_registry.ex
@@ -298,6 +298,7 @@ defmodule DungeonCrawl.DungeonProcesses.LevelRegistry do
 
     send(instance_process, :perform_actions)
     send(instance_process, :player_torch_timeout)
+    send_after(instance_process, :garbage_collect, 300_000)
     ref = Process.monitor(instance_process)
     refs = Map.put(refs, ref, {level_instance.number, level_instance.player_location_id})
 

--- a/lib/dungeon_crawl/dungeon_processes/level_registry.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_registry.ex
@@ -298,7 +298,7 @@ defmodule DungeonCrawl.DungeonProcesses.LevelRegistry do
 
     send(instance_process, :perform_actions)
     send(instance_process, :player_torch_timeout)
-    send_after(instance_process, :garbage_collect, 300_000)
+    Process.send_after(instance_process, :garbage_collect, 300_000)
     ref = Process.monitor(instance_process)
     refs = Map.put(refs, ref, {level_instance.number, level_instance.player_location_id})
 

--- a/lib/dungeon_crawl/dungeon_processes/level_registry.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_registry.ex
@@ -298,6 +298,7 @@ defmodule DungeonCrawl.DungeonProcesses.LevelRegistry do
 
     send(instance_process, :perform_actions)
     send(instance_process, :player_torch_timeout)
+    Process.send_after(instance_process, :write_db, 180_000)
     ref = Process.monitor(instance_process)
     refs = Map.put(refs, ref, {level_instance.number, level_instance.player_location_id})
 

--- a/lib/dungeon_crawl/dungeon_processes/level_registry.ex
+++ b/lib/dungeon_crawl/dungeon_processes/level_registry.ex
@@ -298,7 +298,6 @@ defmodule DungeonCrawl.DungeonProcesses.LevelRegistry do
 
     send(instance_process, :perform_actions)
     send(instance_process, :player_torch_timeout)
-    Process.send_after(instance_process, :garbage_collect, 300_000)
     ref = Process.monitor(instance_process)
     refs = Map.put(refs, ref, {level_instance.number, level_instance.player_location_id})
 

--- a/lib/dungeon_crawl/dungeon_processes/levels.ex
+++ b/lib/dungeon_crawl/dungeon_processes/levels.ex
@@ -471,6 +471,7 @@ defmodule DungeonCrawl.DungeonProcesses.Levels do
     program_contexts = Map.delete(program_contexts, tile_id)
     passage_exits = Enum.reject(passage_exits, fn({id, _}) -> id == tile_id end)
     dirty_ids = if mark_as_dirty, do: Map.put(state.dirty_ids, tile_id, :deleted), else: state.dirty_ids
+    dirty_ids = if is_integer(tile_id), do: dirty_ids, else: Map.delete(dirty_ids, tile_id)
 
     tile = by_id[tile_id]
 

--- a/lib/dungeon_crawl/horde/node_observer.ex
+++ b/lib/dungeon_crawl/horde/node_observer.ex
@@ -1,7 +1,7 @@
 defmodule DungeonCrawl.Horde.NodeObserver do
   use GenServer
 
-  alias DungeonCrawl.Horde.{Registry, Supervisor}
+  alias DungeonCrawl.Horde.{Registry, DungeonSupervisor}
 
   def start_link(_), do: GenServer.start_link(__MODULE__, [])
 
@@ -13,14 +13,14 @@ defmodule DungeonCrawl.Horde.NodeObserver do
 
   def handle_info({:nodeup, _node, _node_type}, state) do
     set_members(Registry)
-    set_members(Supervisor)
+    set_members(DungeonSupervisor)
 
     {:noreply, state}
   end
 
   def handle_info({:nodedown, _node, _node_types}, state) do
     set_members(Registry)
-    set_members(Supervisor)
+    set_members(DungeonSupervisor)
 
     {:noreply, state}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -76,7 +76,7 @@ defmodule DungeonCrawl.Mixfile do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test"],
+      test: ["ecto.create --quiet", "ecto.migrate", "test --exclude horde"],
       "assets.deploy": ["esbuild default --minify", "phx.digest"],
     ]
   end

--- a/test/dungeon_crawl/dungeon_processes/dungeon_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/dungeon_registry_test.exs
@@ -110,9 +110,6 @@ defmodule DungeonCrawl.DungeonRegistryTest do
 
     assert di_ids = DungeonRegistry.list(map_set_registry)
     assert %{^di_id => pid} = di_ids
-    # Shared registry, so this is going to be flakey until everything
-    # is cleaned up properly
-    assert length(Map.keys(di_ids)) == 1
 
     # cleanup
     GenServer.stop(pid, :shutdown)

--- a/test/dungeon_crawl/dungeon_processes/dungeon_registry_test.exs
+++ b/test/dungeon_crawl/dungeon_processes/dungeon_registry_test.exs
@@ -37,7 +37,7 @@ defmodule DungeonCrawl.DungeonRegistryTest do
       assert :error = DungeonRegistry.lookup(map_set_registry, di.id)
       :timer.sleep 5
     end)
-    assert log =~ ~r/warning.*?PID.*?appears to be dead for dungeon id #{di.id}; removing/
+    assert log =~ ~r/warning.*?rpc call returned: 'false' for PID #{ inspect msi_process } for dungeon id #{di.id}; removing/
 
     # no cleanup needed; msi_process is already dead
   end
@@ -83,7 +83,7 @@ defmodule DungeonCrawl.DungeonRegistryTest do
       assert :ok = DungeonRegistry.create(map_set_registry, di.id)
       :timer.sleep 5
     end)
-    assert log =~ ~r/warning.*?PID.*?appears to be dead for dungeon id #{di.id}; removing/
+    assert log =~ ~r/warning.*?rpc call returned: 'false' for PID #{ inspect msi_process } for dungeon id #{di.id}; removing/
 
     # no cleanup needed; msi_process is already dead
   end

--- a/test/dungeon_crawl/horde/dungeon_supervisor_test.exs
+++ b/test/dungeon_crawl/horde/dungeon_supervisor_test.exs
@@ -7,6 +7,7 @@ defmodule DungeonCrawl.Horde.DungeonSupervisorTest do
 
   # Mostly smoke testing, the supervisor is hit by many other parts of the system
 
+  @tag :horde
   test "start_child/1" do
     di = insert_stubbed_dungeon_instance()
 
@@ -20,6 +21,7 @@ defmodule DungeonCrawl.Horde.DungeonSupervisorTest do
     assert {:error, {:already_started, ^dpid}} = DungeonSupervisor.start_child(child_spec)
   end
 
+  @tag :horde
   test "which_children/0" do
     # nothing started yet
     assert [] == DungeonSupervisor.which_children()

--- a/test/dungeon_crawl/horde/node_observer_test.exs
+++ b/test/dungeon_crawl/horde/node_observer_test.exs
@@ -3,6 +3,7 @@ defmodule DungeonCrawl.Horde.NodeObserverTest do
 
   alias DungeonCrawl.Horde.NodeObserver
 
+  @tag :horde
   test "nodeup" do
     {:ok, pid} = NodeObserver.start_link([[name: "TEST1"]])
     Process.send(pid, {:nodeup, :node, :node_type}, [])
@@ -12,6 +13,7 @@ defmodule DungeonCrawl.Horde.NodeObserverTest do
     assert length(members) == 1
   end
 
+  @tag :horde
   test "nodedown" do
     {:ok, pid} = NodeObserver.start_link([[name: "TEST2"]])
     Process.send(pid, {:nodedown, :node, :node_type}, [])


### PR DESCRIPTION
Adding a tag to skip Horde related tests
Gracefully handle when a process/node goes down and does not update the registry; leaving a dead PID referenced by a dungeon id, allowing it to be removed and the process restarted.