### PR TITLE
BugFix - imports - scripts had placeholder slugs instead of the correct slug

### DIFF
--- a/lib/dungeon_crawl/shipping/dungeon_imports.ex
+++ b/lib/dungeon_crawl/shipping/dungeon_imports.ex
@@ -38,6 +38,9 @@ defmodule DungeonCrawl.Shipping.DungeonImports do
              |> find_or_create_assets(import_id, :tile_templates, user)
              |> _break_if_waiting_on_asset_imports(import_id)
     # at this point, bail if there are ambiguous matches that are unresolved
+             |> create_and_add_slugs_to_built_assets(:sounds)
+             |> create_and_add_slugs_to_built_assets(:items)
+             |> create_and_add_slugs_to_built_assets(:tile_templates)
              |> swap_scripts_to_tmp_scripts(:tiles)
              |> repoint_ttids_and_slugs(:tiles)
              |> repoint_ttids_and_slugs(:items)

--- a/lib/dungeon_crawl_web/templates/editor/dungeon/import_live.html.heex
+++ b/lib/dungeon_crawl_web/templates/editor/dungeon/import_live.html.heex
@@ -43,7 +43,7 @@
       <%= for import <- @imports do %>
         <tr>
           <%= if @is_admin do %><td><%= import.user.username %></td><% end %>
-          <td><%= import.file_name %></td>
+          <td><%= link(import.file_name, to: Routes.edit_dungeon_import_path(@socket, :dungeon_import_show, import.id), class: "text-reset text-decoration-none") %></td>
           <td><%= import.inserted_at %></td>
           <%= td_status(import) %>
           <td><%= waiting_or_dungeon_link(@socket, DungeonCrawl.Repo.preload(import, :dungeon)) %></td>

--- a/lib/dungeon_crawl_web/templates/editor/dungeon/modal/import_asset_items_diff.html.eex
+++ b/lib/dungeon_crawl_web/templates/editor/dungeon/modal/import_asset_items_diff.html.eex
@@ -29,14 +29,14 @@
         @existing_attributes[:consumable],
         @attributes[:consumable]) %>
 
-  <%= if @existing_attributes[:script] != @attributes[:script] do %>
+  <%= if @existing_attributes[:fuzzed_script] != @attributes[:fuzzed_script] do %>
   <div class="row">
     <div class="col-2">
       <strong>Script:</strong>
     </div>
     <div class="col-10">
-      <textarea id="scriptExisting<%= @asset_import_id %>"><%= @existing_attributes[:script] %></textarea>
-      <textarea id="scriptImported<%= @asset_import_id %>"><%= @attributes[:script] %></textarea>
+      <textarea id="scriptExisting<%= @asset_import_id %>"><%= @existing_attributes[:fuzzed_script] %></textarea>
+      <textarea id="scriptImported<%= @asset_import_id %>"><%= @attributes[:fuzzed_script] %></textarea>
       <div id="scriptAnchor<%= @asset_import_id %>"></div>
     </div>
   </div>

--- a/test/dungeon_crawl/shipping/dock_worker_test.exs
+++ b/test/dungeon_crawl/shipping/dock_worker_test.exs
@@ -6,6 +6,7 @@ defmodule DungeonCrawl.Shipping.DockWorkerTest do
   alias DungeonCrawl.Dungeons
   alias DungeonCrawl.Shipping
   alias DungeonCrawl.Shipping.{DungeonExports, Json}
+  alias DungeonCrawl.Equipment
   alias DungeonCrawl.Equipment.Seeder, as: EquipmentSeeder
   alias DungeonCrawl.Sound.Seeder, as: SoundSeeder
   alias DungeonCrawl.TileTemplates
@@ -108,6 +109,8 @@ defmodule DungeonCrawl.Shipping.DockWorkerTest do
     dungeon = insert_dungeon(%{user_id: user.id, state: "starting_equipment: #{ item.slug }" })
     data = DungeonExports.run(dungeon.id) |> Json.encode!()
     TileTemplates.update_tile_template(tile_template, %{color: "blue"})
+    {:ok, _} = Equipment.delete_item(item)
+
     dungeon_import = Shipping.create_import!(%{
       data: data,
       user_id: user.id,
@@ -130,6 +133,7 @@ defmodule DungeonCrawl.Shipping.DockWorkerTest do
              [:status, :user_id, :file_name, :line_identifier])
     assert %{log: log} = Shipping.get_import!(dungeon_import.id)
     assert String.contains?(log, "tile_templates - asset exists by slug, creating asset import record")
+    assert String.contains?(log, "whip - items - no match found, flagging asset as buildable")
   end
 
   @tag capture_log: true

--- a/test/dungeon_crawl/shipping/dungeon_imports_test.exs
+++ b/test/dungeon_crawl/shipping/dungeon_imports_test.exs
@@ -392,8 +392,8 @@ defmodule DungeonCrawl.Shipping.DungeonImportsTest do
       # dungeon not created
       refute Map.has_key?(dungeon, :__struct__)
 
-      # ambiguous item not created
-      assert 1 == Enum.count(Equipment.list_items()) - item_count
+      # ambiguous item not created, not are completely new items or other assets
+      assert 0 == Enum.count(Equipment.list_items()) - item_count
 
       # asset import record created
       assert DungeonImports.get_asset_import(config.dungeon_import.id, :items, "tmp_item_id_0")
@@ -408,7 +408,7 @@ defmodule DungeonCrawl.Shipping.DungeonImportsTest do
       [end_time_log | _] = log
       [start_time_log | _] = Enum.reverse(log)
 
-      assert length(log) == 19 # start, end, and all the asset logging; this will change if new things are to be logged
+      assert length(log) == 29 # start, end, and all the asset logging; this will change if new things are to be logged
 
       assert start_time_log =~ ~r/Start: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC/
       assert end_time_log =~ ~r/End: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC/

--- a/test/dungeon_crawl/shipping/private/import_functions_test.exs
+++ b/test/dungeon_crawl/shipping/private/import_functions_test.exs
@@ -44,8 +44,8 @@ defmodule DungeonCrawl.Shipping.Private.ImportFunctionsTest do
         config[:user_asset] -> %{user_id: user.id}
         config[:public_asset] -> %{user_id: nil, public: true}
         config[:others_existing_asset] -> %{user_id: other_user.id, slug: asset_from_import.slug, name: "Common field"}
-        config[:existing_asset] -> %{user_id: user.id, slug: asset_from_import.slug, name: "Common field"}
-        config[:script_asset] -> %{user_id: user.id, script: "test words"}
+        config[:existing_asset] -> %{user_id: user.id, slug: asset_from_import.slug, name: "Common field", script: "test"}
+        config[:script_asset] -> %{user_id: user.id, script: "test words\n#sound tmp_sound1\n#become slug: tmp_ttid_1"}
         true -> %{}
       end
       attrs = Map.merge(asset_from_import, attrs)

--- a/test/dungeon_crawl/shipping/private/import_functions_test.exs
+++ b/test/dungeon_crawl/shipping/private/import_functions_test.exs
@@ -392,6 +392,72 @@ defmodule DungeonCrawl.Shipping.Private.ImportFunctionsTest do
     end
   end
 
+  describe "create_and_add_slugs_to_built_assets/2" do
+    setup do
+      export = %DungeonExports{
+        sounds: %{
+          "tmp_sound_1" => %{zzfx_params: ""},
+          "tmp_sound_2" => {:createable, %{zzfx_params: "[,0,130.8128,.1,.1,.34,3,1.88,,,,,,,,.1,,.5,.04]", name: "blorp"}, "blorp"}
+        },
+        items: %{
+          "tmp_item_0" => {:createable, %{name: "test item", script: "#end"}, "test_item"},
+          "tmp_item_1" => %{script: "does nothing"}
+        },
+        tile_templates: %{
+          "tmp_ttid_0" => %{script: "#end\n:touch\nhey"},
+          "tmp_ttid_1" => {:createable, %{name: "Test Rock", script: "#end", description: "its rock"}, "rock"}
+        }
+      }
+       %{ export: export }
+    end
+
+    test "creates the assets marked as completely new", %{export: export} do
+      assert 0 == Enum.count(Sound.list_effects())
+      assert 0 == Enum.count(Equipment.list_items())
+      assert 0 == Enum.count(TileTemplates.list_tile_templates())
+
+      assert %{sounds: %{
+        "tmp_sound_1" => sound_0,
+        "tmp_sound_2" => sound_1
+      }} = create_and_add_slugs_to_built_assets(export, :sounds)
+      assert 1 == Enum.count(Sound.list_effects())
+      assert sound_0 == export.sounds["tmp_sound_1"]
+      assert sound_1 == Sound.get_effect!("blorp")
+
+      assert %{ items: %{
+        "tmp_item_0" => item_0,
+        "tmp_item_1" => item_1
+      }} = create_and_add_slugs_to_built_assets(export, :items)
+      assert 1 == Enum.count(Equipment.list_items())
+      assert Map.delete(item_0, :tmp_script) == Equipment.get_item!("test_item")
+      assert item_1 == export.items["tmp_item_1"]
+
+      assert %{tile_templates: %{
+        "tmp_ttid_0" => tt_0,
+        "tmp_ttid_1" => tt_1
+      }} = create_and_add_slugs_to_built_assets(export, :tile_templates)
+      assert 1 == Enum.count(TileTemplates.list_tile_templates())
+      assert tt_0 == export.tile_templates["tmp_ttid_0"]
+      assert Map.delete(tt_1, :tmp_script) == TileTemplates.get_tile_template("test_rock", nil)
+    end
+
+    test "does not impact anything other than the specified assets", %{export: export} do
+      assert Map.drop(export, [:sounds, :log]) ==
+               Map.drop(create_and_add_slugs_to_built_assets(export, :sounds), [:sounds, :log])
+      assert Map.drop(export, [:items, :log]) ==
+               Map.drop(create_and_add_slugs_to_built_assets(export, :items), [:items, :log])
+      assert Map.drop(export, [:tile_templates, :log]) ==
+               Map.drop(create_and_add_slugs_to_built_assets(export, :tile_templates), [:tile_templates, :log])
+    end
+
+    test "noop when status is not running", export do
+      export = Map.put export, :status, "halt"
+      assert export == create_and_add_slugs_to_built_assets(export, :sounds)
+      assert export == create_and_add_slugs_to_built_assets(export, :items)
+      assert export == create_and_add_slugs_to_built_assets(export, :tile_templates)
+    end
+  end
+
   describe "repoint_ttids_and_slugs/2" do
     setup do
       # The functions called before this one in the importer


### PR DESCRIPTION
Stores the fuzzed script in a different field to show them to the user for comparison. The asset_import had been begin created with an overwritten script that had lost the original temporary slug ids.

Put off creating brand new assets until after any ambiguous matches have been dealt with.
New helper function to create brand new assets.
Added some specs for the new function.
